### PR TITLE
fix: adding metadata for standalone platforms

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -98,6 +98,7 @@ namespace DCL.ABConverter
         {
             this.settings = settings;
             this.env = env;
+            PlatformUtils.currentTarget = settings.buildTarget;
 
             errorReporter = env.errorReporter;
             if (this.settings.reportErrors)
@@ -407,7 +408,7 @@ namespace DCL.ABConverter
                 var shader = newMaterial.shader;
 
                 if (settings.stripShaders)
-                    env.assetDatabase.MarkAssetBundle(env.assetDatabase, shader, shader.name + "_IGNORE");
+                    env.assetDatabase.MarkAssetBundle(env.assetDatabase, shader, shader.name + "_IGNORE" + PlatformUtils.GetPlatform());
 
                 var textureProperties = GetTextureProperties(shader);
 
@@ -625,12 +626,7 @@ namespace DCL.ABConverter
                 if (assetPath == null) continue;
 
                 if (assetPath.finalPath.EndsWith(".bin")) continue;
-                string assetBundleName = assetPath.hash;
-
-                if (target == BuildTarget.StandaloneWindows64)
-                    assetBundleName += "_windows";
-                else if (target == BuildTarget.StandaloneOSX)
-                    assetBundleName += "_osx";
+                string assetBundleName = assetPath.hash + PlatformUtils.GetPlatform();
 
                 env.directory.MarkFolderForAssetBundleBuild(assetPath.finalPath, assetBundleName);
             }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleMetadataBuilder.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleMetadataBuilder.cs
@@ -28,7 +28,7 @@ namespace DCL.ABConverter
 
                 if (deps.Length > 0)
                 {
-                    deps = deps.Where(s => !s.EndsWith("_IGNORE")).ToArray();
+                    deps = deps.Where(s => !s.Contains("_IGNORE")).ToArray();
 
                     metadata.dependencies = deps.Select(x =>
                                                  {
@@ -43,7 +43,7 @@ namespace DCL.ABConverter
                 string json = JsonUtility.ToJson(metadata);
                 string assetHashName = assetBundles[i];
 
-                hashLowercaseToHashProper.TryGetValue(assetBundles[i], out assetHashName);
+                hashLowercaseToHashProper.TryGetValue(PlatformUtils.RemovePlatform(assetBundles[i]), out assetHashName);
 
                 if (!string.IsNullOrEmpty(assetHashName)) { file.WriteAllText(path + $"/{assetHashName}/metadata.json", json); }
             }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
@@ -57,6 +57,36 @@ namespace DCL.ABConverter
         }
     }
 
+    public static class PlatformUtils
+    {
+
+        public static BuildTarget currentTarget;
+
+        public static string GetPlatform()
+        {
+            if (currentTarget == BuildTarget.StandaloneWindows64)
+                return "_windows";
+            if (currentTarget == BuildTarget.StandaloneOSX)
+                return "_osx";
+            if (Application.platform == RuntimePlatform.LinuxPlayer)
+                return "_linux";
+
+            return ""; //Means we are in WebGL, no extra parameters needed
+        }
+
+        //This method removes the platform from the path, since they are absolute in the downloaded project
+        public static string RemovePlatform(string pathToRemovePlatform)
+        {
+            string currentPlatform = GetPlatform();
+
+            if (string.IsNullOrEmpty(currentPlatform))
+                return pathToRemovePlatform;
+
+            string updatedPath = pathToRemovePlatform.Replace(currentPlatform, "");
+            return updatedPath;
+        }
+    }
+
     public static class PathUtils
     {
         /// <summary>


### PR DESCRIPTION
Some tiding up was required when using _platform.

1) For shader dependencies, the `_platform` was required to standardize the way we search the asset bundle in the ECS project.
2) I had to remove the `_platform` when writing the metadata file in the downloaded folder. I could have added the `_platform` in the Downloaded platform path, but going this way seemed cleaner since I didnt find a standarize path that I could touch