### PR TITLE
feat: Add a possibility to convert empty parcels from the Editor

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleSceneConversionWindow.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleSceneConversionWindow.cs
@@ -26,6 +26,7 @@ namespace AssetBundleConverter
         private const string TAB_RANDOM = "Random Pointer";
         private const string TAB_WEARABLES_COLLECTION = "Wearables Collection";
         private const string TEST_BATCHMODE = "Test Batchmode";
+        private const string EMPTY_SCENES = "Empty Scenes";
         private const string URL_PEERS = "Peers";
         private const string URL_WORLDS = "Worlds";
         private const string CUSTOM = "Custom";
@@ -33,12 +34,13 @@ namespace AssetBundleConverter
         private const string PEERS_URL = "https://peer.decentraland.org/content/contents/";
         private const string WORLDS_URL = "https://worlds-content-server.decentraland.org/contents/";
 
-        private readonly string[] tabs = { TAB_SCENE, TAB_PARCELS, TAB_RANDOM, TAB_WEARABLES_COLLECTION, TEST_BATCHMODE };
+        private readonly string[] tabs = { TAB_SCENE, TAB_PARCELS, TAB_RANDOM, TAB_WEARABLES_COLLECTION, TEST_BATCHMODE, EMPTY_SCENES };
         private readonly string[] urlOptions = { URL_PEERS, URL_WORLDS, CUSTOM };
 
         private string entityId = "QmYy2TMDEfag99yZV4ZdpjievYUfdQgBVfFHKCDAge3zQi";
         private string wearablesCollectionId = "urn:decentraland:off-chain:base-avatars";
         private string debugEntity = "bafkreib66ufmbowp4ee2u3kdu6t52kouie7kd7tfrlv3l5kejz6yjcaq5i";
+        private string mappingName = "../mappings.json";
         private string batchBaseUrl = "";
         private string batchSceneId = "";
         private string batchModeParams = "";
@@ -110,6 +112,9 @@ namespace AssetBundleConverter
                         break;
                     case 4:
                         RenderTestBatchmode();
+                        break;
+                    case 5:
+                        RenderEmptyScenesAsync();
                         break;
                 }
             }
@@ -196,6 +201,26 @@ namespace AssetBundleConverter
                 try
                 {
                     var state = await SceneClient.ConvertEntityById(clientSettings);
+                    OnConversionEnd(state);
+                }
+                catch (Exception e) { Debug.LogException(e); }
+            }
+        }
+
+        private async Task RenderEmptyScenesAsync()
+        {
+            mappingName = EditorGUILayout.TextField("Mapping Name", mappingName);
+
+            GUILayout.FlexibleSpace();
+
+            if (GUILayout.Button("Start"))
+            {
+                SetupSettings();
+                clientSettings.targetHash = mappingName;
+
+                try
+                {
+                    var state = await SceneClient.ConvertEmptyScenesByMapping(clientSettings);
                     OnConversionEnd(state);
                 }
                 catch (Exception e) { Debug.LogException(e); }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
@@ -278,6 +278,12 @@ namespace DCL.ABConverter
             return await ConvertEntitiesToAssetBundles(mappings.ToArray(), settings);
         }
 
+        public static async Task<AssetBundleConverter.State> ConvertEmptyScenesByMapping(ClientSettings settings)
+        {
+            EnsureEnvironment();
+            return await ConvertEntitiesToAssetBundles(await Utils.GetEmptyScenesMappingAsync(settings.targetHash, settings, env.webRequest), settings);
+        }
+
         /// <summary>
         /// Dump a single decentraland entity given a pointer
         /// </summary>

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
@@ -295,6 +295,31 @@ namespace DCL.ABConverter
             return parcelInfoApiData.ToArray();
         }
 
+        public static async Task<MappingPair[]> GetEmptyScenesMappingAsync(string mappingName, ClientSettings settings, IWebRequest webRequest)
+        {
+            var url = $"{settings.baseUrl}{mappingName}";
+            Debug.Log(url);
+
+            DownloadHandler downloadHandler;
+
+            try
+            {
+                downloadHandler = await webRequest.Get(url);
+            }
+            catch (HttpRequestException e)
+            {
+                var exception = new Exception($"Request error! Empty Scenes Mapping couldn't be fetched from {url}! -- {e.Message}");
+                Debug.LogException(exception);
+                Exit((int)AssetBundleConverter.ErrorCodes.UNEXPECTED_ERROR);
+                return null;
+            }
+
+            Dictionary<string, MappingPair[]> mapping = JsonConvert.DeserializeObject<Dictionary<string, MappingPair[]>>(downloadHandler.text);
+            downloadHandler.Dispose();
+
+            return mapping.SelectMany(kvp => kvp.Value).ToArray();
+        }
+
         public static async Task<EntityMappingsDTO[]> GetEntityMappingsAsync(string entityId, ClientSettings settings, IWebRequest webRequest)
         {
             var url = $"{settings.baseUrl}{entityId}";


### PR DESCRIPTION
Empty parcels are defined by `mapping.json` and loaded by Kernel. GLTF assets exist in the `unity-renderer` repo but they are not converted to ABs.
Since `Explorer-Alpha` does not work with GLTF directly this small addition allows to convert all empty scenes with one click.