### PR TITLE
fix: Switch to Scriptable Build Pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ENV PATH $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
 
 # Change this value ONLY if we have done breaking changes for every material, doing so is VERY costly
 ENV AB_VERSION v8
-ENV AB_VERSION_WINDOWS v9
+ENV AB_VERSION_WINDOWS v10
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV production

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.asmdef
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.asmdef
@@ -13,7 +13,9 @@
         "GUID:d0e3b53faf13d4a85bf5db51fc8bfd2f",
         "GUID:08b2edf8f14cdd3408988fd7746b749c",
         "GUID:9887bf5401cdc9140916d3edbea10b69",
-        "GUID:f51ebe6a0ceec4240a699833d6309b23"
+        "GUID:f51ebe6a0ceec4240a699833d6309b23",
+        "GUID:5c1ff9bd975acec488150743d53a93ca",
+        "GUID:c5ecc461727906345a35491a0440694f"
     ],
     "includePlatforms": [
         "Editor"

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleSceneConversionWindow.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleSceneConversionWindow.cs
@@ -54,6 +54,7 @@ namespace AssetBundleConverter
         private int currentUrlOption = 0;
         private int xCoord = -110;
         private int yCoord = -110;
+        private BuildPipelineType buildPipelineType = BuildPipelineType.Scriptable;
         private ShaderType shader = ShaderType.Dcl;
         private SupportedBuildTarget buildTarget = SupportedBuildTarget.WebGL;
 
@@ -76,6 +77,7 @@ namespace AssetBundleConverter
         private void OnGUI()
         {
             GUILayout.Space(5);
+            buildPipelineType = (BuildPipelineType)EditorGUILayout.EnumPopup("Build Pipeline", buildPipelineType);
             buildTarget = (SupportedBuildTarget)EditorGUILayout.EnumPopup("Build Target", buildTarget);
 
             visualTest = EditorGUILayout.Toggle("Visual Test", visualTest);
@@ -308,7 +310,8 @@ namespace AssetBundleConverter
                 importGltf = importGltf,
                 placeOnScene = placeOnScene,
                 verbose = verbose,
-                buildTarget = GetBuildTarget()
+                buildTarget = GetBuildTarget(),
+                BuildPipelineType = buildPipelineType
             };
         }
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
@@ -68,7 +68,7 @@ namespace AssetBundleConverter
             public bool reportErrors = false;
             public bool isWearable;
             public BuildTarget buildTarget = BuildTarget.WebGL;
-            public BuildPipelineType BuildPipelineType = BuildPipelineType.Scriptable;
+            public BuildPipelineType BuildPipelineType = BuildPipelineType.Default;
 
             public ClientSettings Clone() { return MemberwiseClone() as ClientSettings; }
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
@@ -11,6 +11,12 @@ namespace AssetBundleConverter
         GlTFast
     }
 
+    public enum BuildPipelineType
+    {
+        Default,
+        Scriptable
+    }
+
     public class ClientSettings
         {
             /// <summary>
@@ -62,6 +68,7 @@ namespace AssetBundleConverter
             public bool reportErrors = false;
             public bool isWearable;
             public BuildTarget buildTarget = BuildTarget.WebGL;
+            public BuildPipelineType BuildPipelineType = BuildPipelineType.Scriptable;
 
             public ClientSettings Clone() { return MemberwiseClone() as ClientSettings; }
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Config.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Config.cs
@@ -21,6 +21,7 @@ namespace DCL.ABConverter
 
         internal const string CLI_SET_CUSTOM_OUTPUT_ROOT_PATH = "output";
         internal const string CLI_SET_SHADER_TARGET = "shaderTarget";
+        internal const string CLI_BUILD_PIPELINE = "pipeline";
 
         internal static string ASSET_BUNDLE_FOLDER_NAME = "AssetBundles";
         internal static string DOWNLOADED_FOLDER_NAME = "_Downloaded";

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Config.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Config.cs
@@ -21,7 +21,6 @@ namespace DCL.ABConverter
 
         internal const string CLI_SET_CUSTOM_OUTPUT_ROOT_PATH = "output";
         internal const string CLI_SET_SHADER_TARGET = "shaderTarget";
-        internal const string CLI_BUILD_PIPELINE = "pipeline";
 
         internal static string ASSET_BUNDLE_FOLDER_NAME = "AssetBundles";
         internal static string DOWNLOADED_FOLDER_NAME = "_Downloaded";

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Environment.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Environment.cs
@@ -30,16 +30,19 @@ namespace AssetBundleConverter
             this.errorReporter = errorReporter;
         }
 
-        public static Environment CreateWithDefaultImplementations()
+        public static Environment CreateWithDefaultImplementations(BuildPipelineType buildPipelineType)
         {
             var database = new UnityEditorWrappers.AssetDatabase();
+
+            IBuildPipeline pipeline =
+                buildPipelineType == BuildPipelineType.Scriptable ? new ScriptableBuildPipeline() : new UnityEditorWrappers.BuildPipeline();
 
             return new (
                 directory: new DCL.SystemWrappers.Directory(),
                 file: new SystemWrappers.File(),
                 assetDatabase: database,
                 webRequest: new UnityEditorWrappers.WebRequest(),
-                buildPipeline: new UnityEditorWrappers.BuildPipeline(),
+                buildPipeline: pipeline,
                 gltfImporter: new DefaultGltfImporter(database),
                 editor: new AssetBundleEditor(),
                 logger: new ABLogger("[AssetBundleConverter]"),

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Environment.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Environment.cs
@@ -16,8 +16,10 @@ namespace AssetBundleConverter
         public readonly IGltfImporter gltfImporter;
         public readonly IABLogger logger;
         public readonly IErrorReporter errorReporter;
+        public readonly BuildPipelineType buildPipelineType;
 
-        internal Environment(IDirectory directory, IFile file, IAssetDatabase assetDatabase, IWebRequest webRequest, IBuildPipeline buildPipeline, IGltfImporter gltfImporter, IEditor editor, IABLogger logger, IErrorReporter errorReporter)
+        internal Environment(IDirectory directory, IFile file, IAssetDatabase assetDatabase, IWebRequest webRequest, IBuildPipeline buildPipeline, IGltfImporter gltfImporter, IEditor editor, IABLogger logger, IErrorReporter errorReporter,
+            BuildPipelineType buildPipelineType)
         {
             this.directory = directory;
             this.file = file;
@@ -28,6 +30,7 @@ namespace AssetBundleConverter
             this.editor = editor;
             this.logger = logger;
             this.errorReporter = errorReporter;
+            this.buildPipelineType = buildPipelineType;
         }
 
         public static Environment CreateWithDefaultImplementations(BuildPipelineType buildPipelineType)
@@ -46,7 +49,8 @@ namespace AssetBundleConverter
                 gltfImporter: new DefaultGltfImporter(database),
                 editor: new AssetBundleEditor(),
                 logger: new ABLogger("[AssetBundleConverter]"),
-                errorReporter: new ErrorReporter()
+                errorReporter: new ErrorReporter(),
+                buildPipelineType: buildPipelineType
             );
         }
     }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
@@ -249,12 +249,6 @@ namespace DCL.ABConverter
                                       };
             }
 
-            if (Utils.ParseOption(commandLineArgs, Config.CLI_BUILD_PIPELINE, 1, out string[] pipelineParam)
-                && Enum.TryParse(pipelineParam[0], true, out BuildPipelineType pipeline))
-            {
-                settings.BuildPipelineType = pipeline;
-            }
-
             if (Utils.ParseOption(commandLineArgs, Config.CLI_VERBOSE, 0, out _))
                 settings.verbose = true;
 
@@ -266,6 +260,8 @@ namespace DCL.ABConverter
 
             // Target is setup during the commandline argument -buildTarget
             settings.buildTarget = EditorUserBuildSettings.activeBuildTarget;
+
+            settings.BuildPipelineType = settings.buildTarget == BuildTarget.WebGL ? BuildPipelineType.Default : BuildPipelineType.Scriptable;
         }
 
         /// <summary>

--- a/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
@@ -16,8 +16,13 @@ namespace DCL.ABConverter
 
         public static Environment env;
 
-        public static Environment EnsureEnvironment(BuildPipelineType buildPipeline) =>
-            env ??= Environment.CreateWithDefaultImplementations(buildPipeline);
+        public static Environment EnsureEnvironment(BuildPipelineType buildPipeline)
+        {
+            if (env == null || env.buildPipelineType != buildPipeline)
+                env = Environment.CreateWithDefaultImplementations(buildPipeline);
+
+            return env;
+        }
 
         /// <summary>
         /// Scenes conversion batch-mode entry point

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Tests/AssetBundleConverterShould.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Tests/AssetBundleConverterShould.cs
@@ -59,7 +59,7 @@ namespace AssetBundleConverter.Tests
             editor.When(x => x.Exit(Arg.Any<int>())).Do(x => ThrowIfExitCodeIsNotZero(x.Arg<int>()));
             editor.Delay(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 
-            environment = new Environment(directory, file, assetDatabase, webRequest, buildPipeline, gltfImporter, editor, abLogger, errorReporter);
+            environment = new Environment(directory, file, assetDatabase, webRequest, buildPipeline, gltfImporter, editor, abLogger, errorReporter, BuildPipelineType.Default);
 
             var clientSettings = new ClientSettings
             {

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/ScriptableBuildPipeline.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/ScriptableBuildPipeline.cs
@@ -1,0 +1,73 @@
+﻿using AssetBundleConverter.Wrappers.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build.Content;
+using UnityEditor.Build.Pipeline;
+using UnityEditor.Build.Pipeline.Interfaces;
+using UnityEditor.SceneManagement;
+using UnityEngine.Build.Pipeline;
+using BuildCompression = UnityEngine.BuildCompression;
+
+namespace DCL
+{
+    public class ScriptableBuildPipeline : IBuildPipeline
+    {
+        private class Manifest : IAssetBundleManifest
+        {
+            private readonly string[] allAssetBundles;
+            private readonly IReadOnlyDictionary<string, BundleDetails> results;
+
+            public Manifest(IReadOnlyDictionary<string, BundleDetails> results)
+            {
+                allAssetBundles = results.Keys.ToArray();
+                this.results = results;
+            }
+
+            public string[] GetAllAssetBundles() =>
+                allAssetBundles;
+
+            public string[] GetAllDependencies(string assetBundle) =>
+                results.TryGetValue(assetBundle, out var bundleDetails) ? bundleDetails.Dependencies : Array.Empty<string>();
+        }
+
+        public IAssetBundleManifest BuildAssetBundles(string outputPath, BuildAssetBundleOptions options, BuildTarget targetPlatform)
+        {
+            // It's a must to save (or discard) dirty scenes before building asset bundles, otherwise the build will fail.
+            EditorSceneManager.SaveOpenScenes();
+
+            var buildInput = ContentBuildInterface.GenerateAssetBundleBuilds();
+
+            // Address by names instead of paths for backwards compatibility.
+            for (var i = 0; i < buildInput.Length; i++)
+                buildInput[i].addressableNames = buildInput[i].assetNames.Select(Path.GetFileName).ToArray();
+
+            var group = BuildPipeline.GetBuildTargetGroup(targetPlatform);
+            var parameters = new BundleBuildParameters(targetPlatform, group, outputPath);
+
+            // Forcing rebuilt is redundant as SBP respects individual asset changes.
+            //if ((options & BuildAssetBundleOptions.ForceRebuildAssetBundle) != 0)
+            //    parameters.UseCache = false;
+
+            if ((options & BuildAssetBundleOptions.AppendHashToAssetBundleName) != 0)
+                parameters.AppendHash = true;
+
+            if ((options & BuildAssetBundleOptions.ChunkBasedCompression) != 0)
+                parameters.BundleCompression = BuildCompression.LZ4;
+            else if ((options & BuildAssetBundleOptions.UncompressedAssetBundle) != 0)
+                parameters.BundleCompression = BuildCompression.Uncompressed;
+            else
+                parameters.BundleCompression = BuildCompression.LZMA;
+
+            IBundleBuildResults results;
+            ReturnCode exitCode = ContentPipeline.BuildAssetBundles(parameters, new BundleBuildContent(buildInput), out results);
+
+            if (exitCode < ReturnCode.Success)
+                throw new Exception($"Scriptable Build Pipeline failed with code {exitCode}");
+
+            return new Manifest(results.BundleInfos);
+        }
+    }
+}

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/ScriptableBuildPipeline.cs.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/ScriptableBuildPipeline.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f2f3e4a7962945dda38b6eb28311eea5
+timeCreated: 1690651146

--- a/asset-bundle-converter/Packages/manifest.json
+++ b/asset-bundle-converter/Packages/manifest.json
@@ -9,6 +9,7 @@
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.meshopt.decompress": "0.1.0-preview.5",
     "com.unity.render-pipelines.universal": "12.1.10",
+    "com.unity.scriptablebuildpipeline": "1.20.2",
     "com.unity.test-framework": "2.0.1-pre.18",
     "io.sentry.unity": "https://github.com/getsentry/unity.git",
     "net.tnrd.nsubstitute": "https://github.com/decentraland/Unity3D-NSubstitute.git",

--- a/asset-bundle-converter/Packages/packages-lock.json
+++ b/asset-bundle-converter/Packages/packages-lock.json
@@ -111,6 +111,13 @@
         "com.unity.shadergraph": "12.1.10"
       }
     },
+    "com.unity.scriptablebuildpipeline": {
+      "version": "1.20.2",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.searcher": {
       "version": "4.9.1",
       "depth": 2,


### PR DESCRIPTION
All material keywords are not saved in ABs
Unfortunately, it's another [nasty Unity bug](https://issuetracker.unity3d.com/issues/assetbundles-shader-keyword-is-lost-in-build-when-shader-is-in-different-assetbundle-than-material) :facepalm: Emission and Normal map keywords are not saved either.
SHADER KEYWORD IS LOST IN BUILD WHEN SHADER IS IN DIFFERENT ASSETBUNDLE THAN MATERIAL
Perfectly describes the situation.
The reason why it works in the old renderer is because they do this manually:
public static void OptimizeMaterial(Material material)
        {
            //NOTE(Brian): Just enable these keywords so the SRP batcher batches more stuff.
            material.EnableKeyword("_EMISSION");
            material.EnableKeyword("_NORMALMAP");

            if (!material.IsKeywordEnabled("_ALPHATEST_ON") && material.HasProperty(ShaderUtils.Cutoff))
                material.SetFloat(ShaderUtils.Cutoff, 0);

            material.EnableKeyword("_ALPHATEST_ON");
It's a pure hack :melting_face: You never should call anything like this for bundled materials. Also in advance, they of course gather all these materials from loaded Asset Bundles... And I am not going to introduce this weirdness in Explorer Alpha.
The solution to it is using a [new build pipeline](https://docs.unity3d.com/Packages/com.unity.scriptablebuildpipeline@1.21/manual/index.html)
I already modified Asset Bundle Pipeline and it works perfectly with one exception: you can't cross-reference asset bundles generated in old and new ways. E.g. we have a common bundle with the shader, and the old one does not work with newly generated bundles. Most probably because GUIDs are differently generated.
Though, it is still possible to load new ones by the old logic so changes to the client are not needed
I also found a big red flag with our way of generating metadata.json : we run the build twice, the second time forcing a rebuild without caching.
With Scriptable Build Pipeline clearing cache is no longer needed as cache works absolutely differently and is created per asset, not per asset bundle. So it can be reused even if the content of the same asset bundles is reshuffled.
The second bonus is the general performance of SRP which is considerably better.
So after all we will be able to convert Asset Bundles much faster.

- Scriptable Build Pipeline integrated
- `pipeline` CLI option set to `Scriptable` by default, it's possible to change it to `default`