### PR TITLE
fix: scriptable pipeline adding more thhan one gameobject

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ENV PATH $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
 
 # Change this value ONLY if we have done breaking changes for every material, doing so is VERY costly
 ENV AB_VERSION v8
-ENV AB_VERSION_WINDOWS v10
+ENV AB_VERSION_WINDOWS v11
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV production

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -828,7 +828,6 @@ namespace DCL.ABConverter
             DownloadHandler downloadHandler = null;
             string url = settings.baseUrl + assetPath.hash;
 
-            Debug.Log("aaaa " + url);
 
             try
             {

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -117,7 +117,7 @@ namespace DCL.ABConverter
         /// <returns></returns>
         public async Task ConvertAsync(IReadOnlyList<ContentServerUtils.MappingPair> rawContents)
         {
-            if (settings.buildTarget is not (BuildTarget.WebGL or BuildTarget.StandaloneWindows64))
+            if (settings.buildTarget is not (BuildTarget.WebGL or BuildTarget.StandaloneWindows64 or BuildTarget.StandaloneOSX))
             {
                 var message = $"Build target is invalid: {settings.buildTarget.ToString()}";
                 log.Error(message);
@@ -779,9 +779,9 @@ namespace DCL.ABConverter
                     return false;
 
                 List<Task> downloadTasks = new List<Task>();
-                downloadTasks.AddRange( gltfPaths.Select(CreateDownloadTask) );
-                downloadTasks.AddRange( bufferPaths.Select(CreateDownloadTask) );
-                downloadTasks.AddRange( texturePaths.Select(CreateDownloadTask) );
+                downloadTasks.AddRange(gltfPaths.Select(CreateDownloadTask));
+                downloadTasks.AddRange(bufferPaths.Select(CreateDownloadTask));
+                downloadTasks.AddRange(texturePaths.Select(CreateDownloadTask));
 
                 downloadStartupTime = EditorApplication.timeSinceStartup;
 
@@ -810,9 +810,13 @@ namespace DCL.ABConverter
 
                     assetsToMark.Add(ImportGltf(gltfPath));
                 }
+
                 nonGltfImportEndTime = EditorApplication.timeSinceStartup;
             }
-            catch (Exception e) { errorReporter.ReportException(new ConversionException(ConversionStep.Fetch, settings, e)); }
+            catch (Exception e)
+            {
+                errorReporter.ReportException(new ConversionException(ConversionStep.Fetch, settings, e));
+            }
 
             downloadedData = null;
 
@@ -823,6 +827,8 @@ namespace DCL.ABConverter
         {
             DownloadHandler downloadHandler = null;
             string url = settings.baseUrl + assetPath.hash;
+
+            Debug.Log("aaaa " + url);
 
             try
             {

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/ScriptableBuildPipeline.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/ScriptableBuildPipeline.cs
@@ -61,6 +61,8 @@ namespace DCL
             else
                 parameters.BundleCompression = BuildCompression.LZMA;
 
+            parameters.DisableVisibleSubAssetRepresentations = true;
+
             IBundleBuildResults results;
             ReturnCode exitCode = ContentPipeline.BuildAssetBundles(parameters, new BundleBuildContent(buildInput), out results);
 


### PR DESCRIPTION
- Scriptable pipeline had a wrong settings which added more than 1 gameobject to the assetbundle. That was corrected
- Removed mac from restricited platforms