### PR TITLE
chore: shared dependecies cleanup

### DIFF
--- a/asset-bundle-converter/ProjectSettings/GraphicsSettings.asset
+++ b/asset-bundle-converter/ProjectSettings/GraphicsSettings.asset
@@ -53,8 +53,8 @@ GraphicsSettings:
   m_LightmapKeepDynamicDirCombined: 0
   m_LightmapKeepShadowMask: 0
   m_LightmapKeepSubtractive: 0
-  m_FogKeepLinear: 1
-  m_FogKeepExp: 0
+  m_FogKeepLinear: 0
+  m_FogKeepExp: 1
   m_FogKeepExp2: 0
   m_AlbedoSwatchInfos: []
   m_LightsUseLinearIntensity: 1


### PR DESCRIPTION
- Sets exponential fog (the one used in alpha) as default
- Sets unity-shared-dependencies to latest main