### PR TITLE
feat: embed emotes conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ ENV PATH $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
 
 # Change this value ONLY if we have done breaking changes for every material, doing so is VERY costly
 ENV AB_VERSION v13
-ENV AB_VERSION_WINDOWS v17
-ENV AB_VERSION_MAC v18
+ENV AB_VERSION_WINDOWS v18
+ENV AB_VERSION_MAC v19
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV production

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetPath.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetPath.cs
@@ -40,6 +40,9 @@ namespace DCL.ABConverter
         {
             get
             {
+                if (pair.hash.StartsWith("C:", StringComparison.InvariantCultureIgnoreCase))
+                    return pair.hash;
+
                 string fileExt = Path.GetExtension(pair.file);
                 return assetFolder + pair.hash + fileExt;
             }
@@ -50,6 +53,10 @@ namespace DCL.ABConverter
             get
             {
                 char dash = Path.DirectorySeparatorChar;
+
+                if (pair.hash.StartsWith("C:", StringComparison.InvariantCultureIgnoreCase))
+                    return Path.GetDirectoryName(pair.hash) + dash;
+
                 return basePath + pair.hash + dash;
             }
         }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
@@ -77,6 +77,7 @@ namespace AssetBundleConverter
             public bool isWearable;
             public BuildTarget buildTarget = BuildTarget.WebGL;
             public BuildPipelineType BuildPipelineType = BuildPipelineType.Default;
+            public bool removeGLB;
 
             public ClientSettings Clone() { return MemberwiseClone() as ClientSettings; }
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
@@ -360,5 +360,21 @@ namespace DCL.ABConverter
             await core.ConvertAsync(conversionParams);
             return core.CurrentState;
         }
+
+        public static async Task ConvertGLTFListManually(List<ContentServerUtils.MappingPair> filePaths, string entityType, ClientSettings settings)
+        {
+            EnsureEnvironment(settings.BuildPipelineType);
+
+            var core = new AssetBundleConverter(env, settings);
+            await core.ConvertAsync(new AssetBundleConverter.ConversionParams()
+            {
+                apiResponse = new ContentServerUtils.EntityMappingsDTO()
+                {
+                    type = entityType,
+                    content = filePaths.ToArray(),
+                },
+                rawContents = filePaths.ToArray(),
+            });
+        }
     }
 }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/GltFastFileProvider.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/GltFastFileProvider.cs
@@ -136,7 +136,22 @@ namespace AssetBundleConverter.Wrappers.Implementations.Default
         private Uri RebuildUrl(Uri url)
         {
             var absolutePath = url.OriginalString;
-            string relativePath = $"{fileRootPath}{absolutePath.Substring(absolutePath.IndexOf(hash) + hash.Length + 1)}";
+            string relativePath = "";
+            if (absolutePath.StartsWith("C:", StringComparison.InvariantCultureIgnoreCase) || absolutePath.StartsWith("/C:", StringComparison.InvariantCultureIgnoreCase))
+                relativePath = absolutePath;
+            else
+            {
+                if (hash.StartsWith("C:", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    relativePath = hash;
+                }
+                else
+                {
+                    relativePath = $"{fileRootPath}{absolutePath.Substring(absolutePath.IndexOf(hash) + hash.Length + 1)}";
+                }
+
+            }
+
             relativePath = relativePath.Replace("\\", "/");
             return new Uri(relativePath, UriKind.Relative);
         }


### PR DESCRIPTION
In this PR I created a script in `Decentraland > Process Custom Emotes` that lets you select a folder and pre-process all GLB's in there so they have the same format as an embedded emote.

⚠️ This PR was not meant to be merged and was made in order to embed some new emotes quickly, ideally this is not the workflow we want, all base emotes should be on the chain and this service should properly convert them into asset bundles ⚠️ 

⚠️ Its hard-coded for windows specific paths ⚠️ 