### PR TITLE
fix: convert mecanim anims on standalone target

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -349,7 +349,8 @@ namespace DCL.ABConverter
                     ExtractEmbedMaterialsFromGltf(textures, gltf, gltfImport, gltfUrl);
                     embedExtractMaterialTime.Stop();
 
-                    if (animationMethod == AnimationMethod.Mecanim) { CreateAnimatorController(gltfImport, directory); }
+                    if (animationMethod == AnimationMethod.Mecanim)
+                        CreateAnimatorController(gltfImport, directory);
 
                     log.Verbose($"Importing {relativePath}");
 
@@ -453,7 +454,6 @@ namespace DCL.ABConverter
             foreach (AnimationClip clip in clips)
                 loop |= clip.wrapMode == WrapMode.Loop;
 
-            // TODO: should we have a loop parameter for each clip?
             controller.AddParameter(new AnimatorControllerParameter
             {
                 name = LOOP_PARAMETER,

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -449,16 +449,13 @@ namespace DCL.ABConverter
             var filePath = $"{animatorRoot}animatorController.controller";
             var controller = AnimatorController.CreateAnimatorControllerAtPath(filePath);
             var rootStateMachine = controller.layers[0].stateMachine;
-            var loop = false;
-
-            foreach (AnimationClip clip in clips)
-                loop |= clip.wrapMode == WrapMode.Loop;
 
             controller.AddParameter(new AnimatorControllerParameter
             {
                 name = LOOP_PARAMETER,
                 type = AnimatorControllerParameterType.Bool,
-                defaultBool = loop,
+                // All clips are imported as wrapMode=Loop
+                defaultBool = true,
             });
 
             foreach (AnimationClip animationClip in clips)

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -1,16 +1,15 @@
 ﻿using AssetBundleConverter;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using AssetBundleConverter.Editor;
 using AssetBundleConverter.Wrappers.Implementations.Default;
 using AssetBundleConverter.Wrappers.Interfaces;
 using GLTFast;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
@@ -438,6 +437,9 @@ namespace DCL.ABConverter
 
         private void CreateAnimatorController(IGltfImport gltfImport, string directory)
         {
+            var clips = gltfImport.GetClips();
+            if (clips == null) return;
+
             var animatorRoot = $"{directory}/Animator/";
 
             if (!env.directory.Exists(animatorRoot))
@@ -445,8 +447,6 @@ namespace DCL.ABConverter
 
             var filePath = $"{animatorRoot}animatorController.controller";
             var controller = AnimatorController.CreateAnimatorControllerAtPath(filePath);
-            var clips = gltfImport.GetClips();
-
             var rootStateMachine = controller.layers[0].stateMachine;
 
             controller.AddParameter(LOOP_PARAMETER, AnimatorControllerParameterType.Bool);
@@ -488,12 +488,10 @@ namespace DCL.ABConverter
             AssetDatabase.Refresh();
         }
 
-        private AnimationMethod GetAnimationMethod()
-        {
-            if (entityDTO == null) return AnimationMethod.Legacy;
-            if (!entityDTO.type.ToLower().Contains("emote")) return AnimationMethod.Legacy;
-            return settings.buildTarget is BuildTarget.StandaloneWindows64 or BuildTarget.StandaloneOSX ? AnimationMethod.Mecanim : AnimationMethod.Legacy;
-        }
+        private AnimationMethod GetAnimationMethod() =>
+            settings.buildTarget is BuildTarget.StandaloneWindows64 or BuildTarget.StandaloneOSX
+                ? AnimationMethod.Mecanim
+                : AnimationMethod.Legacy;
 
         private void ExtractEmbedMaterialsFromGltf(List<Texture2D> textures, GltfImportSettings gltf, IGltfImport gltfImport, string gltfUrl)
         {

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -448,8 +448,18 @@ namespace DCL.ABConverter
             var filePath = $"{animatorRoot}animatorController.controller";
             var controller = AnimatorController.CreateAnimatorControllerAtPath(filePath);
             var rootStateMachine = controller.layers[0].stateMachine;
+            var loop = false;
 
-            controller.AddParameter(LOOP_PARAMETER, AnimatorControllerParameterType.Bool);
+            foreach (AnimationClip clip in clips)
+                loop |= clip.wrapMode == WrapMode.Loop;
+
+            // TODO: should we have a loop parameter for each clip?
+            controller.AddParameter(new AnimatorControllerParameter
+            {
+                name = LOOP_PARAMETER,
+                type = AnimatorControllerParameterType.Bool,
+                defaultBool = loop,
+            });
 
             foreach (AnimationClip animationClip in clips)
             {


### PR DESCRIPTION
Scene emotes were converted to legacy form, which is not supported in explorer-alpha. This change forces to convert all emotes to mecanim when the target is either windows or osx.