### PR TITLE
Fix: Conversion failure

### DIFF
--- a/asset-bundle-converter/.idea/.idea.asset-bundle-converter/.idea/.gitignore
+++ b/asset-bundle-converter/.idea/.idea.asset-bundle-converter/.idea/.gitignore
@@ -11,3 +11,5 @@
 # Datasource local storage ignored files
 /dataSources/
 /dataSources.local.xml
+# GitHub Copilot persisted chat sessions
+/copilot/chatSessions

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.asmdef
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.asmdef
@@ -16,7 +16,8 @@
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:5c1ff9bd975acec488150743d53a93ca",
         "GUID:c5ecc461727906345a35491a0440694f",
-        "GUID:15fc0a57446b3144c949da3e2b9737a9"
+        "GUID:15fc0a57446b3144c949da3e2b9737a9",
+        "GUID:8c9381414d52c93409d4e7d07e4131cb"
     ],
     "includePlatforms": [
         "Editor"

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -37,44 +37,13 @@ namespace DCL.ABConverter
             public AssetPath AssetPath;
         }
 
-        // For consistency, never remove any of these enum values as it will break old error codes
-        public enum ErrorCodes
-        {
-            SUCCESS,
-            UNDEFINED,
-            SCENE_LIST_NULL,
-            ASSET_BUNDLE_BUILD_FAIL,
-            VISUAL_TEST_FAILED,
-            UNEXPECTED_ERROR,
-            GLTFAST_CRITICAL_ERROR,
-            GLTF_IMPORTER_NOT_FOUND,
-            EMBED_MATERIAL_FAILURE,
-            DOWNLOAD_FAILED,
-            INVALID_PLATFORM,
-            GLTF_PROCESS_MISMATCH,
-        }
-
-        public class State
-        {
-            public enum Step
-            {
-                IDLE,
-                DUMPING_ASSETS,
-                BUILDING_ASSET_BUNDLES,
-                FINISHED,
-            }
-
-            public Step step { get; internal set; }
-            public ErrorCodes lastErrorCode { get; internal set; }
-        }
-
         private const float MAX_TEXTURE_SIZE = 512f;
 
         private const string VERSION = "7.0";
         private const string LOOP_PARAMETER = "Loop";
 
         private readonly Dictionary<string, string> lowerCaseHashes = new ();
-        public State CurrentState { get; } = new ();
+        public ConversionState CurrentState { get; } = new ();
         private Environment env;
         private ClientSettings settings;
         private readonly string finalDownloadedPath;
@@ -84,7 +53,6 @@ namespace DCL.ABConverter
         private Dictionary<string, string> contentTable = new ();
         private Dictionary<string, string> gltfOriginalNames = new ();
         private string logBuffer;
-        private int totalAssets;
         private int skippedAssets;
         private IErrorReporter errorReporter;
 
@@ -101,7 +69,20 @@ namespace DCL.ABConverter
         private double visualTestEndTime;
         private double startupAllocated;
         private double startupReserved;
+
+        /// <summary>
+        /// Total number of GLTFs required by the conversion process
+        /// </summary>
+        private int totalGltfs;
+
+        /// <summary>
+        /// Total number of missing GLTFs
+        /// </summary>
         private int totalGltfsToProcess;
+
+        /// <summary>
+        /// Total number of successfully processed GLTFs
+        /// </summary>
         private int totalGltfsProcessed;
 
         private bool isExitForced = false;
@@ -143,7 +124,7 @@ namespace DCL.ABConverter
                 var message = $"Build target is invalid: {settings.buildTarget.ToString()}";
                 log.Error(message);
                 errorReporter.ReportError(message, settings);
-                ForceExit((int)ErrorCodes.INVALID_PLATFORM);
+                ForceExit(ErrorCodes.INVALID_PLATFORM);
                 return;
             }
 
@@ -168,15 +149,13 @@ namespace DCL.ABConverter
 
             if (settings.importGltf)
             {
-
-                if (!await DownloadAssets(rawContents))
+                if (!await ResolveAssets(rawContents))
                 {
                     log.Info("All assets are already converted");
                     OnFinish();
 
                     return;
                 }
-
             }
 
             // Third step: we import gltfs
@@ -199,14 +178,8 @@ namespace DCL.ABConverter
 
             EditorUtility.ClearProgressBar();
 
-            if (totalGltfsProcessed != totalGltfsToProcess)
-            {
-                var message = $"GLTF count mismatch GLTF to process: {totalGltfsToProcess} vs GLTF processed: {totalGltfsProcessed}";
-                log.Error(message);
-                errorReporter.ReportError(message, settings);
-                ForceExit((int)ErrorCodes.GLTF_PROCESS_MISMATCH);
+            if (TryExitWithGltfErrors())
                 return;
-            }
 
             if (settings.createAssetBundle)
             {
@@ -230,6 +203,30 @@ namespace DCL.ABConverter
             }
 
             OnFinish();
+        }
+
+        private bool TryExitWithGltfErrors()
+        {
+            var failedAssets = totalGltfsToProcess - totalGltfsProcessed;
+            var toleratedCount = Mathf.RoundToInt(settings.failingConversionTolerance * totalGltfs);
+
+            // Try tolerate errors
+            if (failedAssets <= toleratedCount)
+            {
+                log.Warning($"Failed to convert {failedAssets} assets, but tolerating up to {toleratedCount} errors");
+
+                if (failedAssets > 0)
+                    CurrentState.lastErrorCode = ErrorCodes.CONVERSION_ERRORS_TOLERATED;
+
+                return false;
+            }
+
+
+            var message = $"GLTF count mismatch GLTF to process: {totalGltfsToProcess} vs GLTF processed: {totalGltfsProcessed}";
+            log.Error(message);
+            errorReporter.ReportError(message, settings);
+            ForceExit(ErrorCodes.GLTF_PROCESS_MISMATCH);
+            return true;
         }
 
         private void AdjustRenderingMode(BuildTarget targetPlatform)
@@ -256,19 +253,19 @@ namespace DCL.ABConverter
             // Fifth step: we build the Asset Bundles
             env.assetDatabase.Refresh();
             env.assetDatabase.SaveAssets();
-            CurrentState.step = State.Step.BUILDING_ASSET_BUNDLES;
+            CurrentState.step = ConversionState.Step.BUILDING_ASSET_BUNDLES;
 
             if (BuildAssetBundles(target, out var manifest))
             {
                 CleanAssetBundleFolder(manifest.GetAllAssetBundles());
 
                 CurrentState.lastErrorCode = ErrorCodes.SUCCESS;
-                CurrentState.step = State.Step.FINISHED;
+                CurrentState.step = ConversionState.Step.FINISHED;
             }
             else
             {
                 CurrentState.lastErrorCode = ErrorCodes.ASSET_BUNDLE_BUILD_FAIL;
-                CurrentState.step = State.Step.FINISHED;
+                CurrentState.step = ConversionState.Step.FINISHED;
             }
         }
 
@@ -326,7 +323,7 @@ namespace DCL.ABConverter
 
                     if (!loadingSuccess)
                     {
-                        var message = $"GLTF is invalid or contains errors: {gltfImport.LastErrorCode}";
+                        var message = $"GLTF is invalid or contains errors: {gltfUrl}, {gltfImport.LastErrorCode}";
                         log.Error(message);
                         errorReporter.ReportError(message, settings);
                         continue;
@@ -367,8 +364,8 @@ namespace DCL.ABConverter
                             var message = "Fatal error when importing this object, check previous error messages";
                             log.Error(message);
                             errorReporter.ReportError(message, settings);
-                            ForceExit((int)ErrorCodes.GLTFAST_CRITICAL_ERROR);
-                            break;
+                            SetExitState(ErrorCodes.GLTFAST_CRITICAL_ERROR);
+                            continue;
                         }
                     }
                     else
@@ -376,7 +373,7 @@ namespace DCL.ABConverter
                         var message = $"Failed to get the gltf importer for {gltfUrl} \nPath: {relativePath}";
                         log.Error(message);
                         errorReporter.ReportError(message, settings);
-                        ForceExit((int)ErrorCodes.GLTF_IMPORTER_NOT_FOUND);
+                        SetExitState(ErrorCodes.GLTF_IMPORTER_NOT_FOUND);
                         continue;
                     }
 
@@ -406,8 +403,6 @@ namespace DCL.ABConverter
                     log.Verbose($"<color={color}>Ended loading gltf {gltfUrl} with result <b>{loadingSuccess}</b></color>");
                 }
 
-                // This case handles a missing asset, most likely creator's fault, gltf will be skipped
-                catch (AssetNotMappedException e) { Debug.LogError($"<b>{gltf.AssetPath.fileName}</b> will be skipped since one of its dependencies is missing: <b>{e.Message}</b>"); }
                 catch (FileLoadException)
                 {
                     Debug.LogError($"<b>{gltf.AssetPath.fileName} ({gltf.AssetPath.hash})</b> Failed to load since its empty, we will replace this with an empty game object");
@@ -415,16 +410,16 @@ namespace DCL.ABConverter
                     env.assetDatabase.DeleteAsset(relativePath);
                     string prefabPath = Path.ChangeExtension(relativePath, ".prefab");
                     PrefabUtility.SaveAsPrefabAsset(replacement, prefabPath);
+                    // it's not an error so we don't skip the iteration
                 }
                 catch (Exception e)
                 {
                     log.Error("UNCAUGHT FATAL: Failed to load GLTF " + gltf.AssetPath.hash);
                     Debug.LogException(e);
                     errorReporter.ReportException(new ConversionException(ConversionStep.Import, settings, e));
-                    ForceExit((int)ErrorCodes.GLTFAST_CRITICAL_ERROR);
-                    break;
+                    SetExitState(ErrorCodes.GLTFAST_CRITICAL_ERROR);
+                    continue;
                 }
-                finally { gltfImport.Dispose(); }
 
                 totalGltfsProcessed++;
             }
@@ -720,7 +715,7 @@ namespace DCL.ABConverter
 
             logBuffer = $"Conversion finished!. last error code = {CurrentState.lastErrorCode}";
             logBuffer += "\n";
-            logBuffer += $"GLTFs Converted {totalAssets - skippedAssets} of {totalAssets}. (Skipped {skippedAssets})\n";
+            logBuffer += $"GLTFs Converted {totalGltfs - skippedAssets} of {totalGltfs}. (Skipped {skippedAssets})\n";
             logBuffer += $"Total download time: {downloadTime:F} seconds\n";
             logBuffer += $"Total non-gltf import time: {nonGltfImportTime:F} seconds\n";
             logBuffer += $"Total gltf import time: {importTime:F} seconds\n";
@@ -730,7 +725,7 @@ namespace DCL.ABConverter
             logBuffer += $"Total bundle conversion time: {bundlesTime:F} seconds\n";
             logBuffer += "\n";
             logBuffer += $"Total: {conversionTime:F} seconds\n";
-            if (totalAssets > 0) { logBuffer += $"Estimated time per asset: {conversionTime / totalAssets:F}\n"; }
+            if (totalGltfs > 0) { logBuffer += $"Estimated time per asset: {conversionTime / totalGltfs:F}\n"; }
             logBuffer += "\n";
             logBuffer += $"Startup Memory | Allocated: {startupAllocated:F} MB Reserved: {startupReserved:F} MB\n";
             logBuffer += $"End Memory | Allocated: {allocated:F} MB Reserved: {reserved:F} MB\n";
@@ -769,7 +764,7 @@ namespace DCL.ABConverter
             foreach (var gltf in gltfToWait)
                 gltf.import.Dispose();
 
-            ForceExit((int)errorCode);
+            ForceExit(errorCode);
         }
 
         internal void CleanupWorkingFolders()
@@ -814,7 +809,7 @@ namespace DCL.ABConverter
                 var message = "Error generating asset bundle!";
                 log.Error(message);
                 errorReporter.ReportError(message, settings);
-                ForceExit((int)ErrorCodes.ASSET_BUNDLE_BUILD_FAIL);
+                ForceExit(ErrorCodes.ASSET_BUNDLE_BUILD_FAIL);
                 return false;
             }
 
@@ -890,8 +885,7 @@ namespace DCL.ABConverter
         /// <param name="rawContents">An array containing all the assets to be dumped.</param>
         /// <returns>true if succeeded</returns>
         ///
-
-        private async Task<bool> DownloadAssets(IReadOnlyList<ContentServerUtils.MappingPair> rawContents)
+        private async Task<bool> ResolveAssets(IReadOnlyList<ContentServerUtils.MappingPair> rawContents)
         {
             try
             {
@@ -905,16 +899,40 @@ namespace DCL.ABConverter
                 if (!FilterDumpList(ref gltfPaths))
                     return false;
 
-                List<Task> downloadTasks = new List<Task>();
-                downloadTasks.AddRange(gltfPaths.Select(CreateDownloadTask));
-                downloadTasks.AddRange(bufferPaths.Select(CreateDownloadTask));
-                downloadTasks.AddRange(texturePaths.Select(CreateDownloadTask));
+                FilterImportedAssets(gltfPaths, texturePaths, bufferPaths);
+
+                const int BATCH_SIZE = 20;
+
+                List<Task> downloadTasks = new List<Task>(BATCH_SIZE);
 
                 downloadStartupTime = EditorApplication.timeSinceStartup;
 
-                if (settings.clearDirectoriesOnStart)
-                    foreach (Task downloadTask in downloadTasks)
-                        await downloadTask;
+                int totalAssetsToDownload = gltfPaths.Count + bufferPaths.Count + texturePaths.Count;
+                int progress = 0;
+
+                long GetTotalMegabytesDownloaded() =>
+                    downloadedData.Values.Sum(array => array.LongLength) / (1024 * 1024);
+
+                async Task DownloadBatchAsync()
+                {
+                    await Task.WhenAll(downloadTasks);
+                    log.Verbose($"{nameof(ResolveAssets)}: {progress}/{totalAssetsToDownload}; {GetTotalMegabytesDownloaded()} MB");
+                    downloadTasks.Clear();
+                }
+
+                // start and await in batches
+                foreach (AssetPath path in gltfPaths.Concat(bufferPaths).Concat(texturePaths))
+                {
+                    progress++;
+
+                    downloadTasks.Add(CreateDownloadTask(path));
+
+                    if (downloadTasks.Count >= BATCH_SIZE)
+                        await DownloadBatchAsync();
+                }
+
+                // Download last batch
+                if (downloadTasks.Count > 0) await DownloadBatchAsync();
 
                 downloadEndTime = EditorApplication.timeSinceStartup;
 
@@ -947,7 +965,7 @@ namespace DCL.ABConverter
             {
                 Debug.LogException(e);
                 errorReporter.ReportException(new ConversionException(ConversionStep.Fetch, settings, e));
-                ForceExit((int)ErrorCodes.DOWNLOAD_FAILED);
+                ForceExit(ErrorCodes.DOWNLOAD_FAILED);
                 return false;
             }
 
@@ -964,7 +982,7 @@ namespace DCL.ABConverter
                 var message = $"Download Failed by max retry count exceeded, probably a connection error";
                 log.Error(message);
                 errorReporter.ReportError(message, settings);
-                ForceExit((int)ErrorCodes.DOWNLOAD_FAILED);
+                ForceExit(ErrorCodes.DOWNLOAD_FAILED);
                 throw new OperationCanceledException();
             }
 
@@ -1002,7 +1020,7 @@ namespace DCL.ABConverter
                 var message = $"Download Failed {url} -- {e.Message}";
                 log.Error(message);
                 errorReporter.ReportError(message, settings);
-                ForceExit((int)ErrorCodes.DOWNLOAD_FAILED);
+                ForceExit(ErrorCodes.DOWNLOAD_FAILED);
                 return;
             }
 
@@ -1027,6 +1045,74 @@ namespace DCL.ABConverter
         }
 
         /// <summary>
+        /// Removes assets that are already imported from the list
+        /// </summary>
+        private void FilterImportedAssets(List<AssetPath> gltfPaths, List<AssetPath> texturePaths, List<AssetPath> bufferPaths)
+        {
+            // All assets must be re-downloaded
+            if (settings.clearDirectoriesOnStart)
+                return;
+
+            bool CheckAssetIsImported(AssetPath path)
+            {
+                var importer = env.assetDatabase.GetImporterAtPath(path.finalPath);
+
+                if (!importer)
+                    return false;
+
+                var asset = env.assetDatabase.LoadAssetAtPath<Object>(path.finalPath);
+                // in case of a trouble the asset is not imported
+                if (!asset || asset.GetType() == typeof(DefaultAsset))
+                    return false;
+
+                return true;
+            }
+
+            var existingAssetPaths = new List<AssetPath>(gltfPaths.Count + texturePaths.Count + bufferPaths.Count);
+
+            void ProcessImportedAsset(AssetPath assetPath)
+            {
+                existingAssetPaths.Add(assetPath);
+                assetsToMark.Add(assetPath);
+            }
+
+            for (int i = gltfPaths.Count - 1; i >= 0; i--)
+            {
+                var path = gltfPaths[i];
+                if (CheckAssetIsImported(path))
+                {
+                    ProcessImportedAsset(path);
+                    gltfPaths.RemoveAt(i);
+                }
+            }
+
+            AddAssetPathsToContentTable(existingAssetPaths, true);
+            existingAssetPaths.Clear();
+
+            for (int i = texturePaths.Count - 1; i >= 0; i--)
+            {
+                var path = texturePaths[i];
+                if (CheckAssetIsImported(path))
+                {
+                    ProcessImportedAsset(path);
+                    texturePaths.RemoveAt(i);
+                }
+            }
+
+            for (int i = bufferPaths.Count - 1; i >= 0; i--)
+            {
+                var path = bufferPaths[i];
+                if (CheckAssetIsImported(path))
+                {
+                    ProcessImportedAsset(path);
+                    bufferPaths.RemoveAt(i);
+                }
+            }
+
+            AddAssetPathsToContentTable(existingAssetPaths);
+        }
+
+        /// <summary>
         /// Trims off existing asset bundles from the given AssetPath array,
         /// if none exists and shouldAbortBecauseAllBundlesExist is true, it will return false.
         /// </summary>
@@ -1036,7 +1122,7 @@ namespace DCL.ABConverter
         {
             bool shouldBuildAssetBundles;
 
-            totalAssets = gltfPaths.Count;
+            totalGltfs = gltfPaths.Count;
 
             if (settings.skipAlreadyBuiltBundles)
             {
@@ -1298,10 +1384,15 @@ namespace DCL.ABConverter
             return path != null ? gltfPath : null;
         }
 
-        private void ForceExit(int errorCode = 0)
+        private void SetExitState(ErrorCodes error)
+        {
+            CurrentState.lastErrorCode = error;
+        }
+
+        private void ForceExit(ErrorCodes errorCode = ErrorCodes.SUCCESS)
         {
             isExitForced = true;
-            env.editor.Exit(errorCode);
+            env.editor.Exit((int)errorCode);
         }
     }
 }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -164,15 +164,7 @@ namespace DCL.ABConverter
             if (isExitForced)
                 return;
 
-            if (await ProcessAllGltfs())
-            {
-                OnFinish();
-
-                return;
-            }
-
-            if (isExitForced)
-                return;
+            await ProcessAllGltfs();
 
             importEndTime = EditorApplication.timeSinceStartup;
 
@@ -276,7 +268,11 @@ namespace DCL.ABConverter
         private Stopwatch embedExtractTextureTime;
         private Stopwatch embedExtractMaterialTime;
         private Stopwatch configureGltftime;
-        private async Task<bool> ProcessAllGltfs()
+
+        /// <summary>
+        /// Does not force exit
+        /// </summary>
+        private async Task ProcessAllGltfs()
         {
             embedExtractTextureTime = new Stopwatch();
             embedExtractMaterialTime = new Stopwatch();
@@ -302,8 +298,6 @@ namespace DCL.ABConverter
 
             foreach (GltfImportSettings gltf in gltfToWait)
             {
-                if (isExitForced) break;
-
                 string gltfUrl = gltf.url;
                 var gltfImport = gltf.import;
                 string relativePath = PathUtils.FullPathToAssetPath(gltfUrl);
@@ -427,8 +421,6 @@ namespace DCL.ABConverter
             EditorUtility.ClearProgressBar();
 
             log.Info("Ended importing GLTFs");
-
-            return false;
         }
 
         private void CreateAnimatorController(IGltfImport gltfImport, string directory)
@@ -901,9 +893,7 @@ namespace DCL.ABConverter
 
                 FilterImportedAssets(gltfPaths, texturePaths, bufferPaths);
 
-                const int BATCH_SIZE = 20;
-
-                List<Task> downloadTasks = new List<Task>(BATCH_SIZE);
+                List<Task> downloadTasks = new List<Task>(settings.downloadBatchSize);
 
                 downloadStartupTime = EditorApplication.timeSinceStartup;
 
@@ -927,7 +917,7 @@ namespace DCL.ABConverter
 
                     downloadTasks.Add(CreateDownloadTask(path));
 
-                    if (downloadTasks.Count >= BATCH_SIZE)
+                    if (downloadTasks.Count >= settings.downloadBatchSize)
                         await DownloadBatchAsync();
                 }
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleSceneConversionWindow.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleSceneConversionWindow.cs
@@ -48,6 +48,7 @@ namespace AssetBundleConverter
         private bool placeOnScene = true;
         private bool visualTest = false;
         private bool clearDownloads = true;
+        private PersistentSetting<int> downloadBatchSize;
         private PersistentSetting<float> failingConversionTolerance;
         private PersistentSetting<bool> createAssetBundle;
         private PersistentSetting<bool> verbose;
@@ -87,6 +88,7 @@ namespace AssetBundleConverter
             buildPipelineType = PersistentSetting.CreateEnum(nameof(buildPipelineType), BuildPipelineType.Scriptable);
             buildTarget = PersistentSetting.CreateEnum(nameof(buildTarget), SupportedBuildTarget.WebGL);
             failingConversionTolerance = PersistentSetting.CreateFloat(nameof(failingConversionTolerance), 0.05f); // 5%
+            downloadBatchSize = PersistentSetting.CreateInt(nameof(downloadBatchSize), 20);
         }
 
         private void OnGUI()
@@ -98,6 +100,7 @@ namespace AssetBundleConverter
             visualTest = EditorGUILayout.Toggle("Visual Test", visualTest);
             placeOnScene = EditorGUILayout.Toggle("Place on Scene", placeOnScene);
             createAssetBundle.Value = EditorGUILayout.Toggle("Create Asset Bundle", createAssetBundle);
+            downloadBatchSize.Value = ClampDownloadBatchSize(EditorGUILayout.IntField("Download Batch Size", downloadBatchSize));
             failingConversionTolerance.Value = ClampConversionTolerance(EditorGUILayout.FloatField("Failed Conversion Tolerance", failingConversionTolerance));
             clearDownloads = EditorGUILayout.Toggle("Clear Downloads", clearDownloads);
             includeShaderVariants = EditorGUILayout.Toggle("Include Shader Variants", includeShaderVariants);
@@ -312,6 +315,9 @@ namespace AssetBundleConverter
             }
         }
 
+        private int ClampDownloadBatchSize(int value) =>
+            Mathf.Clamp(value, 1, 1000);
+
         private float ClampConversionTolerance(float value) =>
             Mathf.Clamp(value, 0f, 0.5f);
 
@@ -323,6 +329,7 @@ namespace AssetBundleConverter
                 baseUrl = baseUrl,
                 cleanAndExitOnFinish = false,
                 createAssetBundle = createAssetBundle,
+                downloadBatchSize = ClampDownloadBatchSize(downloadBatchSize),
                 failingConversionTolerance = ClampConversionTolerance(failingConversionTolerance),
                 clearDirectoriesOnStart = clearDownloads,
                 importOnlyEntity = showDebugOptions ? debugEntity : "",

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleSceneConversionWindow.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleSceneConversionWindow.cs
@@ -1,12 +1,10 @@
-﻿using AssetBundleConverter.Wearables;
+﻿using AssetBundleConverter.Persistence;
 using System.Threading.Tasks;
-using DCL;
 using DCL.ABConverter;
 using System;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using Random = System.Random;
 
 namespace AssetBundleConverter
 {
@@ -50,16 +48,19 @@ namespace AssetBundleConverter
         private bool placeOnScene = true;
         private bool visualTest = false;
         private bool clearDownloads = true;
-        private bool createAssetBundle = true;
-        private bool verbose = false;
+        private PersistentSetting<float> failingConversionTolerance;
+        private PersistentSetting<bool> createAssetBundle;
+        private PersistentSetting<bool> verbose;
         private int currentTab = 0;
         private int currentUrlOption = 0;
-        private int xCoord = -110;
-        private int yCoord = -110;
-        private BuildPipelineType buildPipelineType = BuildPipelineType.Scriptable;
+
+        private PersistentSetting<int> xCoord;
+        private PersistentSetting<int> yCoord;
+
+        private PersistentSetting<BuildPipelineType> buildPipelineType;
         private ShaderType shader = ShaderType.Dcl;
         private bool includeShaderVariants;
-        private SupportedBuildTarget buildTarget = SupportedBuildTarget.WebGL;
+        private PersistentSetting<SupportedBuildTarget> buildTarget;
 
         private ClientSettings clientSettings;
         private bool showDebugOptions;
@@ -77,15 +78,27 @@ namespace AssetBundleConverter
             thisWindow.Show();
         }
 
+        private void OnEnable()
+        {
+            createAssetBundle = PersistentSetting.CreateBool(nameof(createAssetBundle), true);
+            verbose = PersistentSetting.CreateBool(nameof(verbose), false);
+            xCoord = PersistentSetting.CreateInt(nameof(xCoord), -110);
+            yCoord = PersistentSetting.CreateInt(nameof(yCoord), -110);
+            buildPipelineType = PersistentSetting.CreateEnum(nameof(buildPipelineType), BuildPipelineType.Scriptable);
+            buildTarget = PersistentSetting.CreateEnum(nameof(buildTarget), SupportedBuildTarget.WebGL);
+            failingConversionTolerance = PersistentSetting.CreateFloat(nameof(failingConversionTolerance), 0.05f); // 5%
+        }
+
         private void OnGUI()
         {
             GUILayout.Space(5);
-            buildPipelineType = (BuildPipelineType)EditorGUILayout.EnumPopup("Build Pipeline", buildPipelineType);
-            buildTarget = (SupportedBuildTarget)EditorGUILayout.EnumPopup("Build Target", buildTarget);
+            buildPipelineType.Value = (BuildPipelineType)EditorGUILayout.EnumPopup("Build Pipeline", buildPipelineType);
+            buildTarget.Value = (SupportedBuildTarget)EditorGUILayout.EnumPopup("Build Target", buildTarget);
 
             visualTest = EditorGUILayout.Toggle("Visual Test", visualTest);
             placeOnScene = EditorGUILayout.Toggle("Place on Scene", placeOnScene);
-            createAssetBundle = EditorGUILayout.Toggle("Create Asset Bundle", createAssetBundle);
+            createAssetBundle.Value = EditorGUILayout.Toggle("Create Asset Bundle", createAssetBundle);
+            failingConversionTolerance.Value = ClampConversionTolerance(EditorGUILayout.FloatField("Failed Conversion Tolerance", failingConversionTolerance));
             clearDownloads = EditorGUILayout.Toggle("Clear Downloads", clearDownloads);
             includeShaderVariants = EditorGUILayout.Toggle("Include Shader Variants", includeShaderVariants);
             showDebugOptions = EditorGUILayout.Toggle("Show debug options", showDebugOptions);
@@ -188,7 +201,7 @@ namespace AssetBundleConverter
             stripShaders = EditorGUILayout.Toggle("Strip Shaders", stripShaders);
             importGltf = EditorGUILayout.Toggle("Import GLTFs", importGltf);
             shader = (ShaderType)EditorGUILayout.EnumPopup("Shader Type", shader);
-            verbose = EditorGUILayout.Toggle("Verbose", verbose);
+            verbose.Value = EditorGUILayout.Toggle("Verbose", verbose);
             GUI.color = defaultColor;
             GUILayout.Space(5);
         }
@@ -235,8 +248,8 @@ namespace AssetBundleConverter
 
         private async Task RenderEntityByPointerAsync()
         {
-            xCoord = EditorGUILayout.IntField("X", xCoord);
-            yCoord = EditorGUILayout.IntField("Y", yCoord);
+            xCoord.Value = EditorGUILayout.IntField("X", xCoord);
+            yCoord.Value = EditorGUILayout.IntField("Y", yCoord);
 
             GUILayout.FlexibleSpace();
 
@@ -299,6 +312,9 @@ namespace AssetBundleConverter
             }
         }
 
+        private float ClampConversionTolerance(float value) =>
+            Mathf.Clamp(value, 0f, 0.5f);
+
         private void SetupSettings()
         {
             clientSettings = new ClientSettings
@@ -307,6 +323,7 @@ namespace AssetBundleConverter
                 baseUrl = baseUrl,
                 cleanAndExitOnFinish = false,
                 createAssetBundle = createAssetBundle,
+                failingConversionTolerance = ClampConversionTolerance(failingConversionTolerance),
                 clearDirectoriesOnStart = clearDownloads,
                 importOnlyEntity = showDebugOptions ? debugEntity : "",
                 shaderType = shader,
@@ -320,15 +337,15 @@ namespace AssetBundleConverter
             };
         }
 
-        private void OnConversionEnd(DCL.ABConverter.AssetBundleConverter.State state)
+        private void OnConversionEnd(ConversionState state)
         {
-            if (createAssetBundle && state.lastErrorCode == DCL.ABConverter.AssetBundleConverter.ErrorCodes.SUCCESS)
+            if (createAssetBundle && state.lastErrorCode == ErrorCodes.SUCCESS)
                 EditorUtility.RevealInFinder(Config.ASSET_BUNDLES_PATH_ROOT);
         }
 
         private BuildTarget GetBuildTarget()
         {
-            return buildTarget switch
+            return buildTarget.Value switch
                    {
                        SupportedBuildTarget.WebGL => BuildTarget.WebGL,
                        SupportedBuildTarget.Windows => BuildTarget.StandaloneWindows64,

--- a/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
@@ -58,6 +58,7 @@ namespace AssetBundleConverter
             public bool cleanAndExitOnFinish = true;
             public bool visualTest = false;
             public bool createAssetBundle = true;
+            public int downloadBatchSize = 20;
             public float failingConversionTolerance = 0.05f;
             public bool placeOnScene = true;
             public string importOnlyEntity;

--- a/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
@@ -58,6 +58,7 @@ namespace AssetBundleConverter
             public bool cleanAndExitOnFinish = true;
             public bool visualTest = false;
             public bool createAssetBundle = true;
+            public float failingConversionTolerance = 0.05f;
             public bool placeOnScene = true;
             public string importOnlyEntity;
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/ConversionState.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/ConversionState.cs
@@ -1,0 +1,32 @@
+﻿// unset:none
+namespace DCL.ABConverter
+{
+    public class ConversionState
+    {
+        public enum Step
+        {
+            IDLE,
+            DUMPING_ASSETS,
+            BUILDING_ASSET_BUNDLES,
+            FINISHED,
+        }
+
+        private ErrorCodes errorCode = ErrorCodes.UNDEFINED;
+
+        public Step step { get; internal set; }
+
+        public ErrorCodes lastErrorCode
+        {
+            get => errorCode;
+
+            set
+            {
+                // SUCCESS can't override CONVERSION_ERRORS_TOLERATED
+                if (errorCode == ErrorCodes.CONVERSION_ERRORS_TOLERATED && value == ErrorCodes.SUCCESS)
+                    return;
+
+                errorCode = value;
+            }
+        }
+    }
+}

--- a/asset-bundle-converter/Assets/AssetBundleConverter/ConversionState.cs.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/ConversionState.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7f437aad399c4ea3a0b1d424c4ab747e
+timeCreated: 1719836623

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Editor/CustomGltfImporter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Editor/CustomGltfImporter.cs
@@ -86,7 +86,7 @@ namespace AssetBundleConverter.Editor
             {
                 Debug.LogError("UNCAUGHT FATAL: Failed to Import GLTF " + hash);
                 Debug.LogException(e);
-                Utils.Exit((int)DCL.ABConverter.AssetBundleConverter.ErrorCodes.GLTFAST_CRITICAL_ERROR);
+                Utils.Exit((int)ErrorCodes.GLTFAST_CRITICAL_ERROR);
             }
         }
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/ErrorCodes.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/ErrorCodes.cs
@@ -1,0 +1,22 @@
+﻿namespace DCL.ABConverter
+{
+    /// <summary>
+    /// For consistency, never remove any of these enum values as it will break old error codes
+    /// </summary>
+    public enum ErrorCodes
+    {
+        SUCCESS,
+        UNDEFINED,
+        SCENE_LIST_NULL,
+        ASSET_BUNDLE_BUILD_FAIL,
+        VISUAL_TEST_FAILED,
+        UNEXPECTED_ERROR,
+        GLTFAST_CRITICAL_ERROR,
+        GLTF_IMPORTER_NOT_FOUND,
+        EMBED_MATERIAL_FAILURE,
+        DOWNLOAD_FAILED,
+        INVALID_PLATFORM,
+        GLTF_PROCESS_MISMATCH,
+        CONVERSION_ERRORS_TOLERATED
+    }
+}

--- a/asset-bundle-converter/Assets/AssetBundleConverter/ErrorCodes.cs.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/ErrorCodes.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8c1f19b44d154d638223c461d3e1307c
+timeCreated: 1719835679

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Persistence.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Persistence.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 374c20d66e3b4c73beaba01718590bc2
+timeCreated: 1719831063

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Persistence/Persistence.asmdef
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Persistence/Persistence.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Persistence",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Persistence/Persistence.asmdef.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Persistence/Persistence.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8c9381414d52c93409d4e7d07e4131cb
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Persistence/PersistentSetting.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Persistence/PersistentSetting.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using Unity.Collections.LowLevel.Unsafe;
+using UnityEditor;
+
+namespace AssetBundleConverter.Persistence
+{
+    public static class PersistentSetting
+    {
+        private const string PROJECT_PREFIX = "ASSET_BUNDLE_CONVERTER_";
+
+        public static PersistentSetting<bool> CreateBool(string key, bool defaultValue)
+        {
+            key = PROJECT_PREFIX + key;
+
+            PersistentSetting<bool>.SetAccessors(
+                static (key, defaultValue) => EditorPrefs.GetInt(key, defaultValue ? 1 : 0) == 1,
+                static (key, value) => EditorPrefs.SetInt(key, value ? 1 : 0)
+            );
+
+            return new PersistentSetting<bool>(key, defaultValue);
+        }
+
+        public static PersistentSetting<int> CreateInt(string key, int defaultValue)
+        {
+            key = PROJECT_PREFIX + key;
+
+            PersistentSetting<int>.SetAccessors(
+                static (key, defaultValue) => EditorPrefs.GetInt(key, defaultValue),
+                static (key, value) => EditorPrefs.SetInt(key, value)
+            );
+
+            return new PersistentSetting<int>(key, defaultValue);
+        }
+
+        public static PersistentSetting<float> CreateFloat(string key, float defaultValue)
+        {
+            key = PROJECT_PREFIX + key;
+
+            PersistentSetting<float>.SetAccessors(
+                static (key, defaultValue) => EditorPrefs.GetFloat(key, defaultValue),
+                static (key, value) => EditorPrefs.SetFloat(key, value)
+            );
+
+            return new PersistentSetting<float>(key, defaultValue);
+        }
+
+        public static PersistentSetting<T> CreateEnum<T>(string key, T defaultValue) where T: unmanaged, Enum
+        {
+            PersistentSetting<T>.SetAccessors(
+                static (key, defaultValue) => FromInt<T>(EditorPrefs.GetInt(key, ToInt(defaultValue))),
+                static (key, value) => EditorPrefs.SetInt(key, ToInt(value))
+            );
+
+            return new PersistentSetting<T>(key, defaultValue);
+        }
+
+        private static unsafe int ToInt<T>(T @enum) where T: unmanaged, Enum
+        {
+            return sizeof(T) switch
+                   {
+                       sizeof(byte) => *(byte*)&@enum,
+                       sizeof(short) => *(short*)&@enum,
+                       sizeof(int) => *(int*)&@enum,
+                       sizeof(long) => (int)*(long*)&@enum,
+                       _ => 0,
+                   };
+        }
+
+        private static unsafe T FromInt<T>(int value) where T: unmanaged, Enum
+        {
+            switch (sizeof(T))
+            {
+                case sizeof(byte):
+                    var @byte = (byte)value;
+                    return UnsafeUtility.As<byte, T>(ref @byte);
+                case sizeof(short):
+                    var @short = (short)value;
+                    return UnsafeUtility.As<short, T>(ref @short);
+                case sizeof(int):
+                    return UnsafeUtility.As<int, T>(ref value);
+                case sizeof(long):
+                    var @long = (long)value;
+                    return UnsafeUtility.As<long, T>(ref @long);
+                default: return default(T);
+            }
+        }
+    }
+
+    public readonly struct PersistentSetting<T>
+    {
+        private static Func<string, T, T> getValue;
+        private static Action<string, T> setValue;
+        internal readonly T defaultValue;
+
+        private readonly string key;
+
+        public PersistentSetting(string key, T defaultValue)
+        {
+            this.key = key;
+            this.defaultValue = defaultValue;
+            Value = getValue!(key, defaultValue)!;
+        }
+
+        public static void SetAccessors(Func<string, T, T> getValueFunc, Action<string, T> setValueFunc)
+        {
+            getValue ??= getValueFunc;
+            setValue ??= setValueFunc;
+        }
+
+        public T Value
+        {
+            get => getValue!(key, defaultValue)!;
+            set => setValue!(key, value);
+        }
+
+        public static implicit operator T(PersistentSetting<T> setting) => setting.Value;
+    }
+}

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Persistence/PersistentSetting.cs.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Persistence/PersistentSetting.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 74c82637d26d4417bfd38323ed9d8768
+timeCreated: 1719831428

--- a/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
@@ -44,7 +44,7 @@ namespace DCL.ABConverter
             catch (Exception e)
             {
                 Debug.LogException(e);
-                Utils.Exit((int)AssetBundleConverter.ErrorCodes.UNEXPECTED_ERROR);
+                Utils.Exit((int)ErrorCodes.UNEXPECTED_ERROR);
             }
         }
 
@@ -67,7 +67,7 @@ namespace DCL.ABConverter
             catch (Exception e)
             {
                 Debug.LogException(e);
-                Utils.Exit((int)AssetBundleConverter.ErrorCodes.UNEXPECTED_ERROR);
+                Utils.Exit((int)ErrorCodes.UNEXPECTED_ERROR);
             }
         }
 
@@ -164,7 +164,7 @@ namespace DCL.ABConverter
             {
                 Debug.LogException(e);
                 log.Exception(e.ToString());
-                Utils.Exit((int)AssetBundleConverter.ErrorCodes.UNEXPECTED_ERROR);
+                Utils.Exit((int)ErrorCodes.UNEXPECTED_ERROR);
             }
         }
 
@@ -273,7 +273,7 @@ namespace DCL.ABConverter
         /// <param name="entityId">The scene cid in the multi-hash format (i.e. Qm...etc)</param>
         /// <param name="settings">Conversion settings</param>
         /// <returns>A state context object useful for tracking the conversion progress</returns>
-        public static async Task<AssetBundleConverter.State> ConvertEntityById(ClientSettings settings)
+        public static async Task<ConversionState> ConvertEntityById(ClientSettings settings)
         {
             EnsureEnvironment(settings.BuildPipelineType);
 
@@ -288,7 +288,7 @@ namespace DCL.ABConverter
             }, settings);
         }
 
-        public static async Task<AssetBundleConverter.State> ConvertEmptyScenesByMapping(ClientSettings settings)
+        public static async Task<ConversionState> ConvertEmptyScenesByMapping(ClientSettings settings)
         {
             EnsureEnvironment(settings.BuildPipelineType);
             ContentServerUtils.MappingPair[] emptyScenesMapping = await Utils.GetEmptyScenesMappingAsync(settings.targetHash, settings, env.webRequest);
@@ -304,7 +304,7 @@ namespace DCL.ABConverter
         /// <param name="pointer">The entity position in world</param>
         /// <param name="settings">Conversion settings</param>
         /// <returns>A state context object useful for tracking the conversion progress</returns>
-        public static async Task<AssetBundleConverter.State> ConvertEntityByPointer(ClientSettings settings)
+        public static async Task<ConversionState> ConvertEntityByPointer(ClientSettings settings)
         {
             EnsureEnvironment(settings.BuildPipelineType);
 
@@ -319,10 +319,10 @@ namespace DCL.ABConverter
             }, settings);
         }
 
-        private static AssetBundleConverter.State GetUnexpectedResult() =>
-            new (){step = AssetBundleConverter.State.Step.IDLE, lastErrorCode = AssetBundleConverter.ErrorCodes.UNEXPECTED_ERROR};
+        private static ConversionState GetUnexpectedResult() =>
+            new (){step = ConversionState.Step.IDLE, lastErrorCode = ErrorCodes.UNEXPECTED_ERROR};
 
-        public static async Task<AssetBundleConverter.State> ConvertWearablesCollection(ClientSettings settings)
+        public static async Task<ConversionState> ConvertWearablesCollection(ClientSettings settings)
         {
             EnsureEnvironment(settings.BuildPipelineType);
 
@@ -341,13 +341,13 @@ namespace DCL.ABConverter
         /// <param name="entitiesId">The cid list for the scenes to gather from the catalyst's content server</param>
         /// <param name="settings">Any conversion settings object, if its null, a new one will be created</param>
         /// <returns>A state context object useful for tracking the conversion progress</returns>
-        private static async Task<AssetBundleConverter.State> ConvertEntitiesToAssetBundles(AssetBundleConverter.ConversionParams conversionParams, ClientSettings settings)
+        private static async Task<ConversionState> ConvertEntitiesToAssetBundles(AssetBundleConverter.ConversionParams conversionParams, ClientSettings settings)
         {
             var mappingPairs = conversionParams.rawContents;
             if (mappingPairs == null || mappingPairs.Count == 0)
             {
                 log.Error("Entity list is null or count == 0! Maybe this sector lacks scenes or content requests failed?");
-                return new AssetBundleConverter.State { lastErrorCode = AssetBundleConverter.ErrorCodes.SCENE_LIST_NULL };
+                return new ConversionState { lastErrorCode = ErrorCodes.SCENE_LIST_NULL };
             }
 
             log.Info($"Converting {mappingPairs.Count} entities...");

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
@@ -305,7 +305,7 @@ namespace DCL.ABConverter
             catch (HttpRequestException e)
             {
                 Debug.LogException(new Exception($"Request error! mappings couldn't be fetched for scene {entityPointer}! -- {e.Message}"));
-                Exit((int)AssetBundleConverter.ErrorCodes.UNEXPECTED_ERROR);
+                Exit((int)ErrorCodes.UNEXPECTED_ERROR);
                 return null;
             }
 
@@ -332,7 +332,7 @@ namespace DCL.ABConverter
             {
                 var exception = new Exception($"Request error! Empty Scenes Mapping couldn't be fetched from {url}! -- {e.Message}");
                 Debug.LogException(exception);
-                Exit((int)AssetBundleConverter.ErrorCodes.UNEXPECTED_ERROR);
+                Exit((int)ErrorCodes.UNEXPECTED_ERROR);
                 return null;
             }
 
@@ -356,7 +356,7 @@ namespace DCL.ABConverter
             {
                 var exception = new Exception($"Request error! mappings couldn't be fetched for scene {entityId}! -- {e.Message}");
                 Debug.LogException(exception);
-                Exit((int)AssetBundleConverter.ErrorCodes.UNEXPECTED_ERROR);
+                Exit((int)ErrorCodes.UNEXPECTED_ERROR);
                 return null;
             }
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/GltFastFileProvider.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/GltFastFileProvider.cs
@@ -147,7 +147,7 @@ namespace AssetBundleConverter.Wrappers.Implementations.Default
             bool isContained = contentTable.ContainsKey(originalPath);
 
             if (!isContained)
-                throw new AssetNotMappedException(originalPath);
+                throw new AssetNotMappedException(originalPath, hash);
 
             string finalPath = contentTable[originalPath];
             return new Uri(finalPath, UriKind.Relative);
@@ -168,9 +168,15 @@ namespace AssetBundleConverter.Wrappers.Implementations.Default
 
     public class AssetNotMappedException : Exception
     {
-        public AssetNotMappedException(string message) : base(message)
-        {
+        private readonly string missingDependency;
+        private readonly string fileName;
 
+        public AssetNotMappedException(string missingDependency, string fileName) : base(missingDependency)
+        {
+            this.missingDependency = missingDependency;
+            this.fileName = fileName;
         }
+
+        public override string Message => $"<b>{fileName}</b> will be skipped since one of its dependencies is missing: <b>{missingDependency}</b>";
     }
 }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Interfaces/IGltfImport.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Interfaces/IGltfImport.cs
@@ -1,12 +1,13 @@
 ﻿using GLTFast;
 using GLTFast.Logging;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnityEngine;
 
 namespace AssetBundleConverter.Wrappers.Interfaces
 {
-    public interface IGltfImport
+    public interface IGltfImport : IDisposable
     {
         Task Load(string gltfUrl, ImportSettings importSettings);
 
@@ -21,8 +22,6 @@ namespace AssetBundleConverter.Wrappers.Interfaces
         Material GetMaterial(int index);
 
         IReadOnlyList<AnimationClip> GetClips();
-
-        void Dispose();
 
         Material defaultMaterial { get; }
 


### PR DESCRIPTION
Fixes https://github.com/decentraland/unity-explorer/issues/1291

* Introduced 5% tolerance for failing conversion
* Introduced downloading in batches to prevent SSL error
* Introduced persistent settings to save parameters of the conversion window into Editor Prefs
* Introduced partial downloading till completion instead of full clean-up, useful for debugging/testing with a lot of required assets for the scene