### PR TITLE
feat: anim layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ ENV PATH $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
 
 # Change this value ONLY if we have done breaking changes for every material, doing so is VERY costly
 ENV AB_VERSION v13
-ENV AB_VERSION_WINDOWS v19
-ENV AB_VERSION_MAC v19
+ENV AB_VERSION_WINDOWS v20
+ENV AB_VERSION_MAC v20
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV production

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -471,6 +471,7 @@ namespace DCL.ABConverter
                 // Configure parameters
                 var triggerParameterName = $"{animationClipName}_Trigger";
                 var loopParameterName = $"{animationClipName}_{LOOP_PARAMETER}";
+                var enabledParameterName = $"{animationClipName}_Enabled";
 
                 controller.AddParameter(triggerParameterName, AnimatorControllerParameterType.Trigger);
                 controller.AddParameter(new AnimatorControllerParameter
@@ -478,6 +479,12 @@ namespace DCL.ABConverter
                     name = loopParameterName,
                     type = AnimatorControllerParameterType.Bool,
                     defaultBool = originalClip.wrapMode == WrapMode.Loop,
+                });
+                controller.AddParameter(new AnimatorControllerParameter
+                {
+                    name = enabledParameterName,
+                    type = AnimatorControllerParameterType.Bool,
+                    defaultBool = false,
                 });
 
                 // Configure layers
@@ -492,6 +499,12 @@ namespace DCL.ABConverter
                 var state = controller.AddMotion(clip, layerIndex);
 
                 // Configure transitions
+                // Empty
+                {
+                    AnimatorStateTransition fromAnyStateTransition = layerStateMachine.AddAnyStateTransition(empty);
+                    fromAnyStateTransition.AddCondition(AnimatorConditionMode.IfNot, 0, enabledParameterName);
+                    fromAnyStateTransition.duration = 0;
+                }
                 // Clip
                 {
                     AnimatorStateTransition fromAnyStateTransition = layerStateMachine.AddAnyStateTransition(state);


### PR DESCRIPTION
It is required that two animations play simultaneously on a single animator as it is described here: https://github.com/decentraland/unity-explorer/issues/1087
Directly related to this pr: https://github.com/decentraland/unity-explorer/pull/1369
Therefore, it is needed to provide a layer to each state, so we can set a weight on each layer.