### PR TITLE
fix: dont override anim defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ ENV PATH $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
 
 # Change this value ONLY if we have done breaking changes for every material, doing so is VERY costly
 ENV AB_VERSION v13
-ENV AB_VERSION_WINDOWS v20
-ENV AB_VERSION_MAC v20
+ENV AB_VERSION_WINDOWS v21
+ENV AB_VERSION_MAC v21
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV production

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -497,6 +497,8 @@ namespace DCL.ABConverter
 
                 // Configure states
                 var empty = layerStateMachine.AddState("Empty");
+                // The current animation system expects the clips to stay on its current frame when the execution stops
+                empty.writeDefaultValues = false;
                 var state = controller.AddMotion(clip, layerIndex);
 
                 layerStateMachine.defaultState = isDefaultState ? state : empty;


### PR DESCRIPTION
As it is described in this issue: https://github.com/decentraland/unity-explorer/issues/1376
The doors should stay at the last frame of its open animation when the state is `loop:false`.
By setting the empty state to not override the bone defaults, the animation state will keep its latest state when transitions to `empty`.