### PR TITLE
fix: Cleanup folder before conversion

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/LODsConverter/Scripts/LODConversion.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/LODsConverter/Scripts/LODConversion.cs
@@ -34,8 +34,6 @@ public class LODConversion
 
     public async Task ConvertLODs()
     {
-        //TODO (Juani) Temporal hack. Clean with the regular asset bundle process
-        ClearDownloadedFolder();
         PlatformUtils.currentTarget = EditorUserBuildSettings.activeBuildTarget;
 
         IAssetDatabase assetDatabase = new UnityEditorWrappers.AssetDatabase();
@@ -83,12 +81,6 @@ public class LODConversion
             Debug.Log($"LOD conversion done for {Path.GetFileName(downloadedFilePath)}");
         }
         Utils.Exit();
-    }
-
-    private void ClearDownloadedFolder()
-    {
-        if (Directory.Exists(Config.GetDownloadPath()))
-            Directory.Delete(Config.GetDownloadPath(), true);
     }
 
     private void BuildPrefab(LODPathHandler lodPathHandler, Parcel parcel)

--- a/consumer-server/src/logic/run-conversion.ts
+++ b/consumer-server/src/logic/run-conversion.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs/promises'
 import { dirname } from 'path'
 import { AppComponents } from '../types'
 import { execCommand } from './run-command'
+import syncFs from 'fs'
 
 async function setupStartDirectories(options: {
   logFile: string,
@@ -13,7 +14,10 @@ async function setupStartDirectories(options: {
   // touch logfile and create folders
   await fs.mkdir(dirname(options.logFile), { recursive: true })
   await fs.mkdir(options.outDirectory, { recursive: true })
-  await fs.rmdir(options.projectPath + "/Assets/_Downloaded", { recursive: true });
+  var downloadedPath = options.projectPath + "/Assets/_Downloaded";
+  if (syncFs.existsSync(downloadedPath)) {
+    await fs.rmdir(downloadedPath, { recursive: true });
+  }
   closeSync(openSync(options.logFile, 'w'))
 }
 

--- a/consumer-server/src/logic/run-conversion.ts
+++ b/consumer-server/src/logic/run-conversion.ts
@@ -5,13 +5,15 @@ import { dirname } from 'path'
 import { AppComponents } from '../types'
 import { execCommand } from './run-command'
 
-async function makeLogFileAndOutputDirectoryAvailable(options: {
+async function setupStartDirectories(options: {
   logFile: string,
-  outDirectory: string
+  outDirectory: string,
+  projectPath : string
 }) {
   // touch logfile and create folders
   await fs.mkdir(dirname(options.logFile), { recursive: true })
   await fs.mkdir(options.outDirectory, { recursive: true })
+  await fs.rmdir(options.projectPath + "/Assets/_Downloaded", { recursive: true });
   closeSync(openSync(options.logFile, 'w'))
 }
 
@@ -51,7 +53,7 @@ export async function runLodsConversion(logger: ILoggerComponent.ILogger, compon
   timeout: number,
   unityBuildTarget: string,
 }) {
-  makeLogFileAndOutputDirectoryAvailable(options)
+  setupStartDirectories(options)
 
   const childArg0 = `${options.unityPath}/Editor/Unity`
 
@@ -63,7 +65,8 @@ export async function runLodsConversion(logger: ILoggerComponent.ILogger, compon
     '-logFile', options.logFile,
     '-lods', options.lods.join(';'),
     '-output', options.outDirectory,
-    '-buildTarget', options.unityBuildTarget
+    '-buildTarget', options.unityBuildTarget,
+    '-deleteDownloadPathAfterFinished'  
   ]
 
   return await executeProgram({ logger, components, childArg0, childArguments, projectPath: options.projectPath, timeout: options.timeout })
@@ -83,7 +86,7 @@ export async function runConversion(
     unityBuildTarget: string,
   }
 ) {
-  makeLogFileAndOutputDirectoryAvailable(options)
+  setupStartDirectories(options)
 
   // normalize content server URL
   let contentServerUrl = options.contentServerUrl


### PR DESCRIPTION
- Sets a clean state for asset bundle conversion. Some conversions were falling because old dirty and broken assets where still in the instance