### PR TITLE
fix: add layer state machine into animator asset

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -495,6 +495,8 @@ namespace DCL.ABConverter
                 AnimatorControllerLayer layer = controller.layers[layerIndex];
                 AnimatorStateMachine layerStateMachine = layer.stateMachine;
 
+                AssetDatabase.AddObjectToAsset(layerStateMachine, controller);
+
                 // Configure states
                 var empty = layerStateMachine.AddState("Empty");
                 // The current animation system expects the clips to stay on its current frame when the execution stops


### PR DESCRIPTION
In order to properly export the animator generated for an animated asset, we need to add the layer state machine into the animator asset file. This will allow to export->import the asset in the explorer so it can be debugged in real game runtime.