### PR TITLE
chore: unload optimization

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
@@ -420,6 +421,10 @@ namespace DCL.ABConverter
                     errorReporter.ReportException(new ConversionException(ConversionStep.Import, settings, e));
                     SetExitState(ErrorCodes.GLTFAST_CRITICAL_ERROR);
                     continue;
+                }
+                finally
+                {
+                    await Resources.UnloadUnusedAssets();
                 }
 
                 totalGltfsProcessed++;

--- a/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
@@ -60,7 +60,7 @@ namespace AssetBundleConverter
             public bool createAssetBundle = true;
             public int downloadBatchSize = 20;
             public float failingConversionTolerance = 0.05f;
-            public bool placeOnScene = true;
+            public bool placeOnScene = false;
             public string importOnlyEntity;
 
             public ShaderType shaderType = ShaderType.Dcl;


### PR DESCRIPTION
- Force unload of unnecessary resources after iterating each gltf
- `placeOnScene` is now off by default when not using the converter window. 