### PR TITLE
fix: rebuild dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ ENV PATH=$NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
 
 # Change this value ONLY if we have done breaking changes for every material, doing so is VERY costly
 ENV AB_VERSION=v13
-ENV AB_VERSION_WINDOWS=v25
-ENV AB_VERSION_MAC=v25
+ENV AB_VERSION_WINDOWS=v26
+ENV AB_VERSION_MAC=v26
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV=production

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/ScriptableBuildPipeline.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/ScriptableBuildPipeline.cs
@@ -39,12 +39,6 @@ namespace DCL
             EditorSceneManager.SaveOpenScenes();
 
             var buildInput = ContentBuildInterface.GenerateAssetBundleBuilds();
-
-            //Filter out the DCL asset bundles, as they are not needed for the build.
-            List<AssetBundleBuild> buildInputList = new List<AssetBundleBuild>(buildInput);
-            buildInputList.RemoveAll(item => item.assetBundleName.StartsWith("dcl/"));
-            buildInput = buildInputList.ToArray();
-
             // Address by names instead of paths for backwards compatibility.
             for (var i = 0; i < buildInput.Length; i++)
                 buildInput[i].addressableNames = buildInput[i].assetNames.Select(Path.GetFileName).ToArray();


### PR DESCRIPTION
The dependencies were wrongly removed from the build. We need them to build, if they don't, Unity forceably includes all shaders into ALL ABs. 