### PR TITLE
fix: SRPBatchingHelper OptimizeMaterial only affect WebGL target

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/Editor/CustomGltfImporter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Editor/CustomGltfImporter.cs
@@ -74,7 +74,7 @@ namespace AssetBundleConverter.Editor
             }
 
             if (!useOriginalMaterials)
-                SetupCustomMaterialGenerator(new AssetBundleConverterMaterialGenerator(AssetBundleConverterMaterialGenerator.UseNewShader(EditorUserBuildSettings.activeBuildTarget)));
+                SetupCustomMaterialGenerator(new AssetBundleConverterMaterialGenerator(AssetBundleConverterMaterialGenerator.UseNewShader(EditorUserBuildSettings.activeBuildTarget), EditorUserBuildSettings.activeBuildTarget == BuildTarget.WebGL));
 
             try
             {

--- a/asset-bundle-converter/Assets/AssetBundleConverter/VisualTests.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/VisualTests.cs
@@ -349,13 +349,7 @@ namespace DCL.ABConverter
                             material.shader = Shader.Find("Shader Graphs/glTF-pbrMetallicRoughness");
                         }
 
-                        #if UNITY_EDITOR
-                            if (UnityEditor.EditorUserBuildSettings.selectedBuildTargetGroup == UnityEditor.BuildTargetGroup.WebGL)
-                                SRPBatchingHelper.OptimizeMaterial(material);
-                        #else
-                            if (Application.platform == RuntimePlatform.WebGLPlayer)
-                                SRPBatchingHelper.OptimizeMaterial(material);
-                        #endif
+                        SRPBatchingHelper.OptimizeMaterial(material);
                     }
 
                     if (asset is GameObject assetAsGameObject)

--- a/asset-bundle-converter/Assets/AssetBundleConverter/VisualTests.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/VisualTests.cs
@@ -349,9 +349,13 @@ namespace DCL.ABConverter
                             material.shader = Shader.Find("Shader Graphs/glTF-pbrMetallicRoughness");
                         }
 
-
-                        SRPBatchingHelper.OptimizeMaterial(material);
-
+                        #if UNITY_EDITOR
+                            if (UnityEditor.EditorUserBuildSettings.selectedBuildTargetGroup == UnityEditor.BuildTargetGroup.WebGL)
+                                SRPBatchingHelper.OptimizeMaterial(material);
+                        #else
+                            if (Application.platform == RuntimePlatform.WebGLPlayer)
+                                SRPBatchingHelper.OptimizeMaterial(material);
+                        #endif
                     }
 
                     if (asset is GameObject assetAsGameObject)

--- a/asset-bundle-converter/Assets/AssetBundleConverter/VisualTests.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/VisualTests.cs
@@ -349,7 +349,8 @@ namespace DCL.ABConverter
                             material.shader = Shader.Find("Shader Graphs/glTF-pbrMetallicRoughness");
                         }
 
-                        SRPBatchingHelper.OptimizeMaterial(material);
+                        if (ClientSettings.buildTarget == BuildTarget.WebGL)
+                            SRPBatchingHelper.OptimizeMaterial(material);
                     }
 
                     if (asset is GameObject assetAsGameObject)

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/AssetBundleConverterMaterialGenerator.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/AssetBundleConverterMaterialGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using DCL.GLTFast.Wrappers;
+using DCL.Helpers;
 using DCL.Shaders;
 using GLTFast;
 using UnityEditor;
@@ -9,10 +10,12 @@ namespace AssetBundleConverter.Wrappers.Implementations.Default
     public class AssetBundleConverterMaterialGenerator : DecentralandMaterialGenerator
     {
         private readonly bool useSceneShader;
+        private readonly bool isWebGLPlatform;
 
-        public AssetBundleConverterMaterialGenerator(bool useSceneShader) : base(GetShaderName(useSceneShader))
+        public AssetBundleConverterMaterialGenerator(bool useSceneShader, bool isWebGLPlatform) : base(GetShaderName(useSceneShader))
         {
             this.useSceneShader = useSceneShader;
+            this.isWebGLPlatform = isWebGLPlatform;
         }
 
         public static bool UseNewShader(BuildTarget buildTarget) =>
@@ -33,6 +36,9 @@ namespace AssetBundleConverter.Wrappers.Implementations.Default
                 mat.EnableKeyword(ShaderUtils.FW_PLUS_SHADOWS_CASCADE);
                 mat.EnableKeyword(ShaderUtils.FW_PLUS_SHADOWS_SOFT);
             }
+
+            if(isWebGLPlatform)
+                SRPBatchingHelper.OptimizeMaterial(mat);
 
             return mat;
         }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/DefaultGltfImporter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/DefaultGltfImporter.cs
@@ -36,7 +36,7 @@ namespace AssetBundleConverter.Wrappers.Implementations.Default
 
         private static IMaterialGenerator GetNewMaterialGenerator(ShaderType shaderType, BuildTarget buildTarget) =>
             shaderType == ShaderType.Dcl
-                ? new AssetBundleConverterMaterialGenerator(AssetBundleConverterMaterialGenerator.UseNewShader(buildTarget))
+                ? new AssetBundleConverterMaterialGenerator(AssetBundleConverterMaterialGenerator.UseNewShader(buildTarget), buildTarget == BuildTarget.WebGL)
                 : null;
 
         public bool ConfigureImporter(string relativePath, ContentMap[] contentMap, string fileRootPath, string hash, ShaderType shaderType,


### PR DESCRIPTION
Fixes the SRP Batcher Helper Optimisations from causing problems on the new Explorer platform but avoids making changes to the older renderer.