### PR TITLE
fix: fixed import of duplicated animation clips

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ ENV PATH=$NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
 
 # Change this value ONLY if we have done breaking changes for every material, doing so is VERY costly
 ENV AB_VERSION=v13
-ENV AB_VERSION_WINDOWS=v26
-ENV AB_VERSION_MAC=v26
+ENV AB_VERSION_WINDOWS=v27
+ENV AB_VERSION_MAC=v27
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV=production

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -448,6 +448,10 @@ namespace DCL.ABConverter
             var filePath = $"{animatorRoot}animatorController.controller";
             var controller = AnimatorController.CreateAnimatorControllerAtPath(filePath);
 
+            List<string> layerNames = new List<string>();
+            foreach (AnimatorControllerLayer animatorControllerLayer in controller.layers)
+                layerNames.Add(animatorControllerLayer.name);
+
             for (var i = 0; i < clips.Count; i++)
             {
                 AnimationClip originalClip = clips[i];
@@ -487,9 +491,10 @@ namespace DCL.ABConverter
 
                 // Configure layers
                 string layerName = controller.MakeUniqueLayerName(animationClipName);
+                layerNames.Add(layerName);
                 controller.AddLayer(new AnimatorControllerLayer
                 {
-                    name = animationClipName,
+                    name = layerName,
                     defaultWeight = isDefaultState ? 1f : 0f,
                     stateMachine = new AnimatorStateMachine(),
                     iKPass = false,
@@ -544,8 +549,8 @@ namespace DCL.ABConverter
 
                 int GetLayerIndex()
                 {
-                    for (var i = 0; i < controller.layers.Length; i++)
-                        if (controller.layers[i].name == layerName)
+                    for (var i = 0; i < layerNames.Count; i++)
+                        if (layerNames[i] == layerName)
                             return i;
 
                     return -1;


### PR DESCRIPTION
This PR improves the processing of the animation clips by speeding up the reading of the layer names via cache and fixed the import of duplicated animation clips