### PR TITLE
fix: reverted mitigation for manifest

### DIFF
--- a/consumer-server/src/logic/conversion-task.ts
+++ b/consumer-server/src/logic/conversion-task.ts
@@ -6,7 +6,6 @@ import { AppComponents } from '../types'
 import { runConversion, runLodsConversion } from './run-conversion'
 import * as fs from 'fs'
 import * as path from 'path'
-import { hasContentChange } from './has-content-changed-task'
 
 type Manifest = {
   version: string
@@ -236,34 +235,19 @@ export async function executeConversion(
   const defaultLoggerMetadata = { entityId, contentServerUrl, version: $AB_VERSION, logFile: s3LogKey }
 
   logger.info('Starting conversion for ' + $BUILD_TARGET, defaultLoggerMetadata)
-  let hasContentChanged = true
-
-  if ($BUILD_TARGET !== 'webgl') {
-    try {
-      hasContentChanged = await hasContentChange(entityId, contentServerUrl, $BUILD_TARGET, outDirectory, logger)
-    } catch (e) {
-      logger.info('HasContentChanged failed with error ' + e)
-    }
-  }
-
-  logger.info(`HasContentChanged for ${entityId} result was ${hasContentChanged}`)
 
   let exitCode
   try {
-    if (hasContentChanged) {
-      exitCode = await runConversion(logger, components, {
-        contentServerUrl,
-        entityId,
-        logFile,
-        outDirectory,
-        projectPath: $PROJECT_PATH,
-        unityPath: $UNITY_PATH,
-        timeout: 120 * 60 * 1000, // 120min temporarily doubled
-        unityBuildTarget: unityBuildTarget
-      })
-    } else {
-      exitCode = 0
-    }
+    exitCode = await runConversion(logger, components, {
+      contentServerUrl,
+      entityId,
+      logFile,
+      outDirectory,
+      projectPath: $PROJECT_PATH,
+      unityPath: $UNITY_PATH,
+      timeout: 120 * 60 * 1000, // 120min temporarily doubled
+      unityBuildTarget: unityBuildTarget
+    })
 
     components.metrics.increment('ab_converter_exit_codes', { exit_code: (exitCode ?? -1)?.toString() })
 


### PR DESCRIPTION
Reverts the conversion task changes to verify content changes to avoid the issue of previously converted ABs to be loaded with errors if there were any