### PR TITLE
fix: Add cache ignore in hasContentChanged

### DIFF
--- a/consumer-server/src/logic/has-content-changed-task.ts
+++ b/consumer-server/src/logic/has-content-changed-task.ts
@@ -27,7 +27,7 @@ async function getManifestFiles(
   env: string,
   logger: ILoggerComponent.ILogger
 ): Promise<any | null> {
-  const url = `https://ab-cdn.decentraland.${env}/manifest/${entityID}_${buildTarget}.json`
+  const url = `https://ab-cdn.decentraland.${env}/manifest/${entityID}_${buildTarget}.json?no-cache=123`
 
   const res = await fetch(url)
   const response = await res.json()


### PR DESCRIPTION
- Adds a fake param to ignore the cache when resolving `hasContentChanged`. This will stop the CDN to return a cached value when two conversions are compared the same day