### PR TITLE
fix: Remove strict error policy

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleSceneConversionWindow.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleSceneConversionWindow.cs
@@ -92,7 +92,7 @@ namespace AssetBundleConverter
             buildPipelineType = PersistentSetting.CreateEnum(nameof(buildPipelineType), BuildPipelineType.Scriptable);
             animationMehtod = PersistentSetting.CreateEnum(nameof(animationMehtod), AnimationMethod.Legacy);
             buildTarget = PersistentSetting.CreateEnum(nameof(buildTarget), SupportedBuildTarget.WebGL);
-            failingConversionTolerance = PersistentSetting.CreateFloat(nameof(failingConversionTolerance), 0.05f); // 5%
+            failingConversionTolerance = PersistentSetting.CreateFloat(nameof(failingConversionTolerance), 1f); // 5%
             downloadBatchSize = PersistentSetting.CreateInt(nameof(downloadBatchSize), 20);
         }
 
@@ -326,7 +326,7 @@ namespace AssetBundleConverter
             Mathf.Clamp(value, 1, 1000);
 
         private float ClampConversionTolerance(float value) =>
-            Mathf.Clamp(value, 0f, 0.5f);
+            Mathf.Clamp(value, 0f, 1f);
 
         private void SetupSettings()
         {

--- a/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/ClientSettings.cs
@@ -65,7 +65,7 @@ namespace AssetBundleConverter
             public bool visualTest = false;
             public bool createAssetBundle = true;
             public int downloadBatchSize = 20;
-            public float failingConversionTolerance = 0.05f;
+        public float failingConversionTolerance = 1f;
             public bool placeOnScene = false;
             public string importOnlyEntity;
 


### PR DESCRIPTION
- Removes the strict error policy that made a scene conversion failed if more than 5% of assets failed. 
- That policy is gone. Now any amount of assets can fail, and the scene will still be converted
- It will keep a error code `12` nonetheless