### PR TITLE
fix: added support for mecanim scene emotes conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ ENV PATH=$NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
 
 # Change this value ONLY if we have done breaking changes for every material, doing so is VERY costly
 ENV AB_VERSION=v13
-ENV AB_VERSION_WINDOWS=v37
-ENV AB_VERSION_MAC=v37
+ENV AB_VERSION_WINDOWS=v38
+ENV AB_VERSION_MAC=v38
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV=production

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -295,7 +295,7 @@ namespace DCL.ABConverter
                 bool isSceneEmote = gltf.AssetPath.fileName.EndsWith("_emote.glb");
                 bool isEmote = entityDTO.type.ToLower().Contains("emote") || isSceneEmote;
 
-                AnimationMethod animationMethod = GetAnimationMethod(isSceneEmote);
+                AnimationMethod animationMethod = GetAnimationMethod(isEmote);
 
                 var importSettings = new ImportSettings
                 {
@@ -620,11 +620,10 @@ namespace DCL.ABConverter
             AssetDatabase.Refresh();
         }
 
-        private AnimationMethod GetAnimationMethod(bool isSceneEmote)
+        private AnimationMethod GetAnimationMethod(bool isEmote)
         {
             if (entityDTO == null) return AnimationMethod.Legacy;
-            if (isSceneEmote) return AnimationMethod.Mecanim;
-            if (entityDTO.type.ToLower().Contains("emote")) return AnimationMethod.Mecanim;
+            if (isEmote) return AnimationMethod.Mecanim;
             if (settings.buildTarget is BuildTarget.StandaloneWindows64 or BuildTarget.StandaloneOSX)
                 return settings.AnimationMethod;
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -292,7 +292,7 @@ namespace DCL.ABConverter
                 string gltfUrl = gltf.url;
                 var gltfImport = gltf.import;
                 string relativePath = PathUtils.FullPathToAssetPath(gltfUrl);
-                bool isEmote = entityDTO.type.ToLower().Contains("emote") || gltf.AssetPath.fileName.EndsWith("_emote.glb");
+                bool isEmote = (entityDTO is { type: not null } && entityDTO.type.ToLower().Contains("emote")) || gltf.AssetPath.fileName.EndsWith("_emote.glb");
 
                 AnimationMethod animationMethod = GetAnimationMethod(isEmote);
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -293,6 +293,8 @@ namespace DCL.ABConverter
                 var gltfImport = gltf.import;
                 string relativePath = PathUtils.FullPathToAssetPath(gltfUrl);
                 bool isSceneEmote = gltf.AssetPath.fileName.EndsWith("_emote.glb");
+                bool isEmote = entityDTO.type.ToLower().Contains("emote") || isSceneEmote;
+
                 AnimationMethod animationMethod = GetAnimationMethod(isSceneEmote);
 
                 var importSettings = new ImportSettings
@@ -343,8 +345,6 @@ namespace DCL.ABConverter
 
                     if (animationMethod == AnimationMethod.Mecanim)
                     {
-                        bool isEmote = entityDTO.type.ToLower().Contains("emote") || gltf.AssetPath.fileName.EndsWith("_emote.glb");
-
                         if (isEmote)
                             CreateAnimatorController(gltfImport, directory);
                         else

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -292,8 +292,7 @@ namespace DCL.ABConverter
                 string gltfUrl = gltf.url;
                 var gltfImport = gltf.import;
                 string relativePath = PathUtils.FullPathToAssetPath(gltfUrl);
-                bool isSceneEmote = gltf.AssetPath.fileName.EndsWith("_emote.glb");
-                bool isEmote = entityDTO.type.ToLower().Contains("emote") || isSceneEmote;
+                bool isEmote = entityDTO.type.ToLower().Contains("emote") || gltf.AssetPath.fileName.EndsWith("_emote.glb");
 
                 AnimationMethod animationMethod = GetAnimationMethod(isEmote);
 


### PR DESCRIPTION
This PR forces scene emotes to be processed as mecanim animations, like it is already done with the regular AB emotes.
To do it I've simply moved the creation of import settings to be generated on a gltf basis, forcing the animation method on assets containing emotes ending in "_emote.glb" as suggested in https://github.com/decentraland/unity-explorer/issues/3455