### PR TITLE
fix: do not allow animation for wearable types

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -343,12 +343,15 @@ namespace DCL.ABConverter
                     ExtractEmbedMaterialsFromGltf(textures, gltf, gltfImport, gltfUrl);
                     embedExtractMaterialTime.Stop();
 
-                    if (animationMethod == AnimationMethod.Mecanim)
+                    if (!entityDTO.type.ToLower().Contains("wearable"))
                     {
-                        if (isEmote)
-                            CreateAnimatorController(gltfImport, directory);
-                        else
-                            CreateLayeredAnimatorController(gltfImport, directory);
+                        if (animationMethod == AnimationMethod.Mecanim)
+                        {
+                            if (isEmote)
+                                CreateAnimatorController(gltfImport, directory);
+                            else
+                                CreateLayeredAnimatorController(gltfImport, directory);
+                        }
                     }
 
                     log.Verbose($"Importing {relativePath}");

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -296,7 +296,7 @@ namespace DCL.ABConverter
                                || gltf.AssetPath.fileName.ToLower().EndsWith("_emote.glb");
                 bool isWearable = (entityDTO is { type: not null } && entityDTO.type.ToLower().Contains("wearable"));
 
-                AnimationMethod animationMethod = GetAnimationMethod(isEmote);
+                AnimationMethod animationMethod = GetAnimationMethod(isEmote,isWearable);
 
                 var importSettings = new ImportSettings
                 {
@@ -305,12 +305,6 @@ namespace DCL.ABConverter
                     AnisotropicFilterLevel = 0,
                     GenerateMipMaps = false
                 };
-                
-                if (isWearable)
-                {
-                    // Setting to None to not import the animation clips
-                    importSettings.AnimationMethod = AnimationMethod.None;
-                }
 
                 try
                 {
@@ -627,9 +621,10 @@ namespace DCL.ABConverter
             AssetDatabase.Refresh();
         }
 
-        private AnimationMethod GetAnimationMethod(bool isEmote)
+        private AnimationMethod GetAnimationMethod(bool isEmote, bool isWearable)
         {
             if (entityDTO == null) return AnimationMethod.Legacy;
+            if (isWearable) return AnimationMethod.None;
             if (isEmote) return AnimationMethod.Mecanim;
             if (settings.buildTarget is BuildTarget.StandaloneWindows64 or BuildTarget.StandaloneOSX)
                 return settings.AnimationMethod;

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -376,20 +376,6 @@ namespace DCL.ABConverter
                             SetExitState(ErrorCodes.GLTFAST_CRITICAL_ERROR);
                             continue;
                         }
-                        
-                        // // NOTE: if type is wearable remove
-                        // // NOTE: the animator and legacy animation
-                        // if (entityDTO.type.ToLower().Contains("wearable"))
-                        // {
-                        //     var animator = importedGameObject.GetComponent<Animator>();
-                        //     if (animator != null) Object.DestroyImmediate(animator, true);
-                        //
-                        //     var legacyAnimation = importedGameObject.GetComponent<Animation>();
-                        //     if (legacyAnimation != null) Object.DestroyImmediate(legacyAnimation, true);
-                        //     
-                        //     EditorUtility.SetDirty(importedGameObject);
-                        //     env.assetDatabase.SaveAssets();
-                        // }
                     }
                     else
                     {

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -294,8 +294,7 @@ namespace DCL.ABConverter
                 string relativePath = PathUtils.FullPathToAssetPath(gltfUrl);
                 bool isEmote = (entityDTO is { type: not null } && entityDTO.type.ToLower().Contains("emote"))
                                || gltf.AssetPath.fileName.ToLower().EndsWith("_emote.glb");
-                bool isWearable = (entityDTO is { type: not null } && entityDTO.type.ToLower().Contains("wearable"))
-                                  || gltf.AssetPath.fileName.ToLower().EndsWith("_wearable.glb");
+                bool isWearable = (entityDTO is { type: not null } && entityDTO.type.ToLower().Contains("wearable"));
 
                 AnimationMethod animationMethod = GetAnimationMethod(isEmote);
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -294,6 +294,8 @@ namespace DCL.ABConverter
                 string relativePath = PathUtils.FullPathToAssetPath(gltfUrl);
                 bool isEmote = (entityDTO is { type: not null } && entityDTO.type.ToLower().Contains("emote"))
                                || gltf.AssetPath.fileName.ToLower().EndsWith("_emote.glb");
+                bool isWearable = (entityDTO is { type: not null } && entityDTO.type.ToLower().Contains("wearable"))
+                                  || gltf.AssetPath.fileName.ToLower().EndsWith("_wearable.glb");
 
                 AnimationMethod animationMethod = GetAnimationMethod(isEmote);
 
@@ -304,6 +306,12 @@ namespace DCL.ABConverter
                     AnisotropicFilterLevel = 0,
                     GenerateMipMaps = false
                 };
+                
+                if (isWearable)
+                {
+                    // Setting to None to not import the animation clips
+                    importSettings.AnimationMethod = AnimationMethod.None;
+                }
 
                 try
                 {
@@ -357,7 +365,7 @@ namespace DCL.ABConverter
                     log.Verbose($"Importing {relativePath}");
 
                     configureGltftime.Start();
-                    bool importerSuccess = env.gltfImporter.ConfigureImporter(relativePath, contentMap, gltf.AssetPath.fileRootPath, gltf.AssetPath.hash, settings.shaderType, animationMethod);
+                    bool importerSuccess = env.gltfImporter.ConfigureImporter(relativePath, contentMap, gltf.AssetPath.fileRootPath, gltf.AssetPath.hash, settings.shaderType, importSettings.AnimationMethod);
                     configureGltftime.Stop();
 
                     if (importerSuccess)
@@ -372,6 +380,20 @@ namespace DCL.ABConverter
                             SetExitState(ErrorCodes.GLTFAST_CRITICAL_ERROR);
                             continue;
                         }
+                        
+                        // // NOTE: if type is wearable remove
+                        // // NOTE: the animator and legacy animation
+                        // if (entityDTO.type.ToLower().Contains("wearable"))
+                        // {
+                        //     var animator = importedGameObject.GetComponent<Animator>();
+                        //     if (animator != null) Object.DestroyImmediate(animator, true);
+                        //
+                        //     var legacyAnimation = importedGameObject.GetComponent<Animation>();
+                        //     if (legacyAnimation != null) Object.DestroyImmediate(legacyAnimation, true);
+                        //     
+                        //     EditorUtility.SetDirty(importedGameObject);
+                        //     env.assetDatabase.SaveAssets();
+                        // }
                     }
                     else
                     {

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -351,15 +351,12 @@ namespace DCL.ABConverter
                     ExtractEmbedMaterialsFromGltf(textures, gltf, gltfImport, gltfUrl);
                     embedExtractMaterialTime.Stop();
 
-                    if (!entityDTO.type.ToLower().Contains("wearable"))
+                    if (animationMethod == AnimationMethod.Mecanim)
                     {
-                        if (animationMethod == AnimationMethod.Mecanim)
-                        {
-                            if (isEmote)
-                                CreateAnimatorController(gltfImport, directory);
-                            else
-                                CreateLayeredAnimatorController(gltfImport, directory);
-                        }
+                        if (isEmote)
+                            CreateAnimatorController(gltfImport, directory);
+                        else
+                            CreateLayeredAnimatorController(gltfImport, directory);
                     }
 
                     log.Verbose($"Importing {relativePath}");


### PR DESCRIPTION
Fix https://github.com/decentraland/unity-explorer/issues/2804
this PR prevents adding animations for wearable types