### PR TITLE
feat: texture budget

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -93,6 +93,7 @@ namespace DCL.ABConverter
         private IABLogger log => env.logger;
         private Dictionary<AssetPath, byte[]> downloadedData = new();
         private ContentServerUtils.EntityMappingsDTO entityDTO;
+        private TexturePixelBudgetEnforcer textureBudgetEnforcer;
         private readonly Dictionary<Shader, List<int>> textureProperties = new ();
 
         public AssetBundleConverter(Environment env, ClientSettings settings)
@@ -173,6 +174,11 @@ namespace DCL.ABConverter
             // Initialize the scene state generator and generate the initial scene state
             env.InitializeSceneStateGenerator(entityDTO);
             env.sceneStateGenerator.GenerateInitialSceneState();
+
+            // If processing a scene instantiate a pixel budget enforcer to be used for automatic compression
+            if (entityDTO is { type: not null } && entityDTO.type.ToLower() == "scene" && entityDTO.pointers != null)
+                textureBudgetEnforcer = new TexturePixelBudgetEnforcer(
+                    entityDTO.pointers.Length, env.file, env.assetDatabase, log);
 
             await ProcessAllGltfs();
 
@@ -345,7 +351,8 @@ namespace DCL.ABConverter
 
                     string directory = Path.GetDirectoryName(relativePath);
 
-                    if (textures.Count > 0) { textures = ExtractEmbedTexturesFromGltf(textures, gltfImport, directory); }
+                    if (textures.Count > 0)
+                        textures = ExtractEmbedTexturesFromGltf(textures, gltfImport, directory, textureBudgetEnforcer);
 
                     embedExtractTextureTime.Stop();
 
@@ -439,6 +446,8 @@ namespace DCL.ABConverter
             EditorUtility.ClearProgressBar();
 
             log.Info("Ended importing GLTFs");
+
+            textureBudgetEnforcer?.EnforceBudgets();
         }
 
         private void CreateLayeredAnimatorController(IGltfImport gltfImport, string directory)
@@ -749,7 +758,7 @@ namespace DCL.ABConverter
 
 
 
-        private List<Texture2D> ExtractEmbedTexturesFromGltf(List<Texture2D> textures, IGltfImport gltfImport, string folderName)
+        private List<Texture2D> ExtractEmbedTexturesFromGltf(List<Texture2D> textures, IGltfImport gltfImport, string folderName, TexturePixelBudgetEnforcer budgetEnforcer = null)
         {
             var newTextures = new List<Texture2D>();
 
@@ -805,6 +814,7 @@ namespace DCL.ABConverter
                         if (loadedAsset != null)
                         {
                             newTextures.Add(loadedAsset);
+                            budgetEnforcer?.TrackTexture(env.assetDatabase.GetAssetPath(loadedAsset), loadedAsset.width, loadedAsset.height, textTypeMan.GetTextureInfo(tex.name).Types);
                             continue;
                         }
                     }
@@ -816,6 +826,7 @@ namespace DCL.ABConverter
                         if (loadedAsset != null)
                         {
                             newTextures.Add(loadedAsset);
+                            budgetEnforcer?.TrackTexture(texturePath, loadedAsset.width, loadedAsset.height, textTypeMan.GetTextureInfo(tex.name).Types);
                             continue;
                         }
                     }
@@ -856,9 +867,14 @@ namespace DCL.ABConverter
 
                     env.assetDatabase.ImportAsset(texPath, ImportAssetOptions.ForceSynchronousImport | ImportAssetOptions.ForceUpdate);
 
-                    ReduceTextureSizeIfNeeded(texPath, maxTextureSize);
+                    if (budgetEnforcer == null)
+                        ReduceTextureSizeIfNeeded(texPath, maxTextureSize);
 
-                    newTextures.Add(env.assetDatabase.LoadAssetAtPath<Texture2D>(texPath));
+                    var extractedTex = env.assetDatabase.LoadAssetAtPath<Texture2D>(texPath);
+                    newTextures.Add(extractedTex);
+
+                    if (budgetEnforcer != null && extractedTex != null)
+                        budgetEnforcer.TrackTexture(texPath, extractedTex.width, extractedTex.height, textTypeMan.GetTextureInfo(tex.name).Types);
                 }
             }
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -814,7 +814,7 @@ namespace DCL.ABConverter
                         if (loadedAsset != null)
                         {
                             newTextures.Add(loadedAsset);
-                            budgetEnforcer?.TrackTexture(env.assetDatabase.GetAssetPath(loadedAsset), loadedAsset.width, loadedAsset.height, textTypeMan.GetTextureInfo(tex.name).Types);
+                            budgetEnforcer?.TrackTexture(env.assetDatabase.GetAssetPath(loadedAsset), texName, loadedAsset.width, loadedAsset.height, textTypeMan.GetTextureInfo(tex.name).Types);
                             continue;
                         }
                     }
@@ -826,7 +826,7 @@ namespace DCL.ABConverter
                         if (loadedAsset != null)
                         {
                             newTextures.Add(loadedAsset);
-                            budgetEnforcer?.TrackTexture(texturePath, loadedAsset.width, loadedAsset.height, textTypeMan.GetTextureInfo(tex.name).Types);
+                            budgetEnforcer?.TrackTexture(texturePath, texName, loadedAsset.width, loadedAsset.height, textTypeMan.GetTextureInfo(tex.name).Types);
                             continue;
                         }
                     }
@@ -874,7 +874,7 @@ namespace DCL.ABConverter
                     newTextures.Add(extractedTex);
 
                     if (budgetEnforcer != null && extractedTex != null)
-                        budgetEnforcer.TrackTexture(texPath, extractedTex.width, extractedTex.height, textTypeMan.GetTextureInfo(tex.name).Types);
+                        budgetEnforcer.TrackTexture(texPath, texName, extractedTex.width, extractedTex.height, textTypeMan.GetTextureInfo(tex.name).Types);
                 }
             }
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Tests/TexturePixelBudgetEnforcerShould.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Tests/TexturePixelBudgetEnforcerShould.cs
@@ -1,0 +1,316 @@
+using AssetBundleConverter;
+using DCL;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace UNITY_INCLUDE_TESTS.AssetBundleConverter.Tests
+{
+    [TestFixture]
+    [Category("EditModeCI")]
+    public class TexturePixelBudgetEnforcerShould
+    {
+        private const long ONE_PARCEL_BUDGET = 2048L * 2048; // 4,194,304 px
+        private const string GLTF_A = "Assets/_Downloaded/gltf_abc123/Textures/";
+        private const string GLTF_B = "Assets/_Downloaded/gltf_def456/Textures/";
+        private const string GLTF_C = "Assets/_Downloaded/gltf_ghi789/Textures/";
+
+        private IFile file;
+        private IAssetDatabase assetDatabase;
+        private IABLogger log;
+
+        [SetUp]
+        public void SetUp()
+        {
+            file = Substitute.For<IFile>();
+            assetDatabase = Substitute.For<IAssetDatabase>();
+            log = Substitute.For<IABLogger>();
+        }
+
+        private TestableEnforcer CreateEnforcer(int parcelCount = 1) =>
+            new (parcelCount, file, assetDatabase, log);
+
+        [Test]
+        public void NotResizeWhenUnderBudget()
+        {
+            var enforcer = CreateEnforcer();
+            enforcer.TrackTexture(GLTF_A + "Albedo.png", "Albedo", 1024, 1024, TextureType.MainTex);
+            enforcer.TrackTexture(GLTF_A + "Normal.png", "Normal", 1024, 1024, TextureType.MainTex);
+
+            enforcer.EnforceBudgets();
+
+            Assert.AreEqual(0, enforcer.ResizeCallCount);
+        }
+
+        [Test]
+        public void ResizeSingleTextureOverBudget()
+        {
+            var enforcer = CreateEnforcer();
+            enforcer.TrackTexture(GLTF_A + "BigAlbedo.png", "BigAlbedo", 4096, 4096, TextureType.MainTex);
+
+            enforcer.EnforceBudgets();
+
+            Assert.Greater(enforcer.ResizeCallCount, 0);
+            var tex = enforcer.GetTracked(GLTF_A + "BigAlbedo.png");
+            Assert.LessOrEqual((long)tex.Width * tex.Height, ONE_PARCEL_BUDGET);
+        }
+
+        [Test]
+        public void ResizeOnlyLargestWhenOneReductionSuffices()
+        {
+            var enforcer = CreateEnforcer();
+            // Total = 2048*2048 + 1024*1024 = 4,194,304 + 1,048,576 = 5,242,880 > 4,194,304
+            enforcer.TrackTexture(GLTF_A + "LargeAlbedo.png", "LargeAlbedo", 2048, 2048, TextureType.MainTex);
+            enforcer.TrackTexture(GLTF_B + "SmallAlbedo.png", "SmallAlbedo", 1024, 1024, TextureType.MainTex);
+
+            enforcer.EnforceBudgets();
+
+            var large = enforcer.GetTracked(GLTF_A + "LargeAlbedo.png");
+            var small = enforcer.GetTracked(GLTF_B + "SmallAlbedo.png");
+
+            long total = ((long)large.Width * large.Height) + ((long)small.Width * small.Height);
+            Assert.LessOrEqual(total, ONE_PARCEL_BUDGET);
+            // Small should not have been touched, the large one absorbs the excess
+            Assert.AreEqual(1024, small.Width);
+            Assert.AreEqual(1024, small.Height);
+        }
+
+        [Test]
+        public void ClampFactorToHalfAndContinueToNextCandidate()
+        {
+            var enforcer = CreateEnforcer();
+            // Two huge textures, both far over budget
+            // Total = 2 * 8192^2 = 134,217,728 >> 4,194,304
+            enforcer.TrackTexture(GLTF_A + "HugeA.png", "HugeA", 8192, 8192, TextureType.MainTex);
+            enforcer.TrackTexture(GLTF_B + "HugeB.png", "HugeB", 8192, 8192, TextureType.MainTex);
+
+            enforcer.EnforceBudgets();
+
+            var a = enforcer.GetTracked(GLTF_A + "HugeA.png");
+            var b = enforcer.GetTracked(GLTF_B + "HugeB.png");
+            long total = ((long)a.Width * a.Height) + ((long)b.Width * b.Height);
+
+            Assert.LessOrEqual(total, ONE_PARCEL_BUDGET);
+            // Both should have been resized (factor clamp forces spread across candidates)
+            Assert.Less(a.Width, 8192);
+            Assert.Less(b.Width, 8192);
+        }
+
+        [Test]
+        public void WrapAroundAndReduceAgain()
+        {
+            var enforcer = CreateEnforcer();
+            // 3 textures, massively over budget, will need multiple passes
+            enforcer.TrackTexture(GLTF_A + "Albedo.png", "Albedo", 4096, 4096, TextureType.MainTex);
+            enforcer.TrackTexture(GLTF_B + "Albedo.png", "Albedo", 4096, 4096, TextureType.MainTex);
+            enforcer.TrackTexture(GLTF_C + "Albedo.png", "Albedo", 4096, 4096, TextureType.MainTex);
+
+            enforcer.EnforceBudgets();
+
+            var a = enforcer.GetTracked(GLTF_A + "Albedo.png");
+            var b = enforcer.GetTracked(GLTF_B + "Albedo.png");
+            var c = enforcer.GetTracked(GLTF_C + "Albedo.png");
+            long total = ((long)a.Width * a.Height) + ((long)b.Width * b.Height) + ((long)c.Width * c.Height);
+
+            Assert.LessOrEqual(total, ONE_PARCEL_BUDGET);
+            // All three should have been resized due to wrap-around
+            Assert.Less(a.Width, 4096);
+            Assert.Less(b.Width, 4096);
+            Assert.Less(c.Width, 4096);
+        }
+
+        [Test]
+        public void NotResizeAlreadyOneByOneTexture()
+        {
+            var enforcer = CreateEnforcer();
+            enforcer.TrackTexture(GLTF_A + "Tiny.png", "Tiny", 1, 1, TextureType.MainTex);
+
+            enforcer.EnforceBudgets();
+
+            Assert.AreEqual(0, enforcer.ResizeCallCount);
+        }
+
+        [Test]
+        public void ReduceTwoByTwoToOneByOneWhenOverBudget()
+        {
+            var enforcer = CreateEnforcer();
+            // 2048 textures of 64x64 = 2048 * 4096 = 8,388,608 > 4,194,304
+            for (int i = 0; i < 2048; i++)
+                enforcer.TrackTexture($"{GLTF_A}tex_{i}.png", $"tex_{i}", 64, 64, TextureType.MainTex);
+
+            // Also add a 2x2 as the smallest candidate
+            enforcer.TrackTexture(GLTF_B + "Tiny.png", "Tiny", 2, 2, TextureType.MainTex);
+
+            enforcer.EnforceBudgets();
+
+            long total = 0;
+            for (int i = 0; i < 2048; i++)
+            {
+                var t = enforcer.GetTracked($"{GLTF_A}tex_{i}.png");
+                total += (long)t.Width * t.Height;
+            }
+            var tiny = enforcer.GetTracked(GLTF_B + "Tiny.png");
+            total += (long)tiny.Width * tiny.Height;
+
+            Assert.LessOrEqual(total, ONE_PARCEL_BUDGET);
+        }
+
+        [Test]
+        public void ReduceOneByNTexture()
+        {
+            var enforcer = CreateEnforcer();
+            // 1x8192 = 8192 px (well under budget alone, so pair with a large texture)
+            // Total = 4096*4096 + 1*8192 = 16,785,408 >> 4,194,304
+            enforcer.TrackTexture(GLTF_A + "Wide.png", "Wide", 1, 8192, TextureType.MainTex);
+            enforcer.TrackTexture(GLTF_B + "Big.png", "Big", 4096, 4096, TextureType.MainTex);
+
+            enforcer.EnforceBudgets();
+
+            var wide = enforcer.GetTracked(GLTF_A + "Wide.png");
+            // Width should stay 1 (Max(1,...)), height should reduce
+            Assert.AreEqual(1, wide.Width);
+        }
+
+        [Test]
+        public void NotResizeWhenNoCandidatesForLayer()
+        {
+            var enforcer = CreateEnforcer();
+            // Only track normal maps, albedo layer should be empty
+            enforcer.TrackTexture(GLTF_A + "Normal.png", "Normal", 4096, 4096, TextureType.BumpMap);
+
+            enforcer.EnforceBudgets();
+
+            // Normal was over budget and got resized, but no crash for empty albedo layer
+            Assert.Greater(enforcer.ResizeCallCount, 0);
+        }
+
+        [Test]
+        public void EnforceLayersIndependently()
+        {
+            var enforcer = CreateEnforcer();
+            // Albedo: over budget
+            enforcer.TrackTexture(GLTF_A + "Albedo.png", "Albedo", 4096, 4096, TextureType.MainTex);
+            // Normal: under budget
+            enforcer.TrackTexture(GLTF_A + "Normal.png", "Normal", 1024, 1024, TextureType.BumpMap);
+
+            enforcer.EnforceBudgets();
+
+            var albedo = enforcer.GetTracked(GLTF_A + "Albedo.png");
+            var normal = enforcer.GetTracked(GLTF_A + "Normal.png");
+
+            Assert.LessOrEqual((long)albedo.Width * albedo.Height, ONE_PARCEL_BUDGET);
+            // Normal should be untouched
+            Assert.AreEqual(1024, normal.Width);
+            Assert.AreEqual(1024, normal.Height);
+        }
+
+        [Test]
+        public void ResizeSharedTextureAffectsBothLayers()
+        {
+            var enforcer = CreateEnforcer();
+            // This texture is both albedo and normal, appears in both layers' candidate lists
+            enforcer.TrackTexture(GLTF_A + "Shared.png", "Shared", 4096, 4096, TextureType.MainTex | TextureType.BumpMap);
+
+            enforcer.EnforceBudgets();
+
+            var shared = enforcer.GetTracked(GLTF_A + "Shared.png");
+            // Should have been resized for albedo layer (over budget: 16M > 4M)
+            Assert.LessOrEqual((long)shared.Width * shared.Height, ONE_PARCEL_BUDGET);
+            // When normal layer is processed, the texture is already within budget, no extra resize needed
+        }
+
+        [Test]
+        public void ScaleBudgetWithParcelCount()
+        {
+            var enforcer = CreateEnforcer(4);
+            // 4 parcels -> budget = 4 * 2048^2 = 16,777,216 px
+            // 4096x4096 = 16,777,216 px, exactly at budget
+            enforcer.TrackTexture(GLTF_A + "Exact.png", "Exact", 4096, 4096, TextureType.MainTex);
+
+            enforcer.EnforceBudgets();
+
+            Assert.AreEqual(0, enforcer.ResizeCallCount);
+        }
+
+        [Test]
+        public void ResizeWhenOnePixelOverBudget()
+        {
+            var enforcer = CreateEnforcer();
+            // Budget = 4,194,304. Track one 2048x2048 (exactly at budget) + one tiny 2x1 (2px over)
+            enforcer.TrackTexture(GLTF_A + "Exact.png", "Exact", 2048, 2048, TextureType.MainTex);
+            enforcer.TrackTexture(GLTF_B + "Tiny.png", "Tiny", 2, 1, TextureType.MainTex);
+
+            enforcer.EnforceBudgets();
+
+            var exact = enforcer.GetTracked(GLTF_A + "Exact.png");
+            var tiny = enforcer.GetTracked(GLTF_B + "Tiny.png");
+            long total = ((long)exact.Width * exact.Height) + ((long)tiny.Width * tiny.Height);
+            Assert.LessOrEqual(total, ONE_PARCEL_BUDGET);
+        }
+
+        [Test]
+        public void SortByPixelCountThenNameThenPath()
+        {
+            var enforcer = CreateEnforcer();
+
+            // Same size (2048x2048), same name "Albedo" but different GLTF folders
+            // Should sort by name first (equal), then by full path (GLTF_A < GLTF_B)
+            // The one with alphabetically first path gets reduced first
+            enforcer.TrackTexture(GLTF_B + "Albedo.png", "Albedo", 2048, 2048, TextureType.MainTex);
+            enforcer.TrackTexture(GLTF_A + "Albedo.png", "Albedo", 2048, 2048, TextureType.MainTex);
+            // Smaller texture, different name
+            enforcer.TrackTexture(GLTF_C + "Detail.png", "Detail", 512, 512, TextureType.MainTex);
+
+            // Total = 2 * 2048^2 + 512^2 = 8,388,608 + 262,144 = 8,650,752 > 4,194,304
+            enforcer.EnforceBudgets();
+
+            var fromA = enforcer.GetTracked(GLTF_A + "Albedo.png");
+            var fromB = enforcer.GetTracked(GLTF_B + "Albedo.png");
+            var detail = enforcer.GetTracked(GLTF_C + "Detail.png");
+
+            long total = ((long)fromA.Width * fromA.Height) + ((long)fromB.Width * fromB.Height) + ((long)detail.Width * detail.Height);
+            Assert.LessOrEqual(total, ONE_PARCEL_BUDGET);
+
+            // GLTF_A path sorts before GLTF_B, so it should be reduced first (at index 0)
+            Assert.Less(fromA.Width, 2048, "Texture from GLTF_A should be reduced first (earlier in path order)");
+        }
+
+        [Test]
+        public void SortByNameBeforePath()
+        {
+            var enforcer = CreateEnforcer();
+
+            // Same size, different names — name should take priority over path
+            // "Alpha" < "Beta" alphabetically, so Alpha sorts first regardless of path
+            enforcer.TrackTexture(GLTF_B + "Alpha.png", "Alpha", 2048, 2048, TextureType.MainTex);
+            enforcer.TrackTexture(GLTF_A + "Beta.png", "Beta", 2048, 2048, TextureType.MainTex);
+            enforcer.TrackTexture(GLTF_C + "Detail.png", "Detail", 512, 512, TextureType.MainTex);
+
+            // Total = 2 * 2048^2 + 512^2 = 8,650,752 > 4,194,304
+            enforcer.EnforceBudgets();
+
+            var alpha = enforcer.GetTracked(GLTF_B + "Alpha.png");
+            var beta = enforcer.GetTracked(GLTF_A + "Beta.png");
+
+            // Alpha sorts before Beta by name, so it gets reduced first even though its path (GLTF_B) is later
+            Assert.Less(alpha.Width, 2048, "Alpha should be reduced first (earlier in name order, despite later path)");
+        }
+
+        private class TestableEnforcer : TexturePixelBudgetEnforcer
+        {
+            public int ResizeCallCount;
+
+            public TestableEnforcer(int parcelCount, IFile file, IAssetDatabase assetDatabase, IABLogger log)
+                : base(parcelCount, file, assetDatabase, log) { }
+
+            protected override void ResizeTrackedTexture(TrackedTexture texture, int newWidth, int newHeight)
+            {
+                texture.Width = newWidth;
+                texture.Height = newHeight;
+                ResizeCallCount++;
+            }
+
+            public TrackedTexture GetTracked(string filePath) =>
+                trackedTextures[filePath];
+        }
+    }
+}

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Tests/TexturePixelBudgetEnforcerShould.cs.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Tests/TexturePixelBudgetEnforcerShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 098437c37642f4cac8106107c38feb1f

--- a/asset-bundle-converter/Assets/AssetBundleConverter/TexturePixelBudgetEnforcer.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/TexturePixelBudgetEnforcer.cs
@@ -9,12 +9,13 @@ using Object = UnityEngine.Object;
 
 namespace AssetBundleConverter
 {
+    [Flags]
     public enum TextureLayer
     {
-        ALBEDO,
-        NORMAL,
-        EMISSIVE,
-        OTHER,
+        ALBEDO   = 1 << 0,
+        NORMAL   = 1 << 1,
+        EMISSIVE = 1 << 2,
+        OTHER    = 1 << 3,
     }
 
     public class TrackedTexture
@@ -76,56 +77,36 @@ namespace AssetBundleConverter
             foreach (var layer in ALL_LAYERS)
             {
                 List<TrackedTexture> candidates = trackedTextures.Values
-                                                .Where(t => GetLayers(t.Types).Contains(layer))
-                                                .ToList();
+                                                                 .Where(t => (GetLayers(t.Types) & layer) != 0)
+                                                                 .ToList();
 
                 if (candidates.Count == 0) continue;
 
-                candidates.Sort(CompareTextures);
-
                 long totalPixels = candidates.Sum(c => c.PixelCount);
-
-                int index = 0;
 
                 while (totalPixels > budgetPerLayer)
                 {
-                    TrackedTexture candidate = candidates[index];
+                    // Sort each time and check biggest texture
+                    candidates.Sort(CompareTextures);
+                    TrackedTexture candidate = candidates[0];
 
                     log.Verbose($"Texture budget: optimizing {candidate.FilePath}");
 
-                    // Knowing that candidates[index + 1] would be same or less size that candidates[index]
-                    // then safely assume this layer cannot be optimized further
+                    // Knowing that candidates[index + 1] would be same or less size than candidates[index]
+                    // safely assume this layer cannot be optimized further
                     if (candidate.Width <= 1 && candidate.Height <= 1)
                     {
                         log.Warning($"Texture budget for layer {layer} cannot be met, largest texture already at 1x1");
                         break;
                     }
 
-                    long excess = totalPixels - budgetPerLayer;
-                    long currentPixels = candidate.PixelCount;
-                    long targetPixels = Math.Max(1, currentPixels - excess);
+                    // Halve the texture
+                    int newWidth = Mathf.Max(1, (int)(candidate.Width * .5f));
+                    int newHeight = Mathf.Max(1, (int)(candidate.Height * .5f));
 
-                    float factor = Mathf.Sqrt((float)targetPixels / currentPixels);
-
-                    // If factor < 0.5, limit to halving the size, it will continue reducing on next iteration,
-                    // this way we reduce the number of wasted pixels
-                    if (factor < 0.5f)
-                        factor = 0.5f;
-
-                    int newWidth = Mathf.Max(1, (int)(candidate.Width * factor));
-                    int newHeight = Mathf.Max(1, (int)(candidate.Height * factor));
-
-                    if (newWidth == candidate.Width && newHeight == candidate.Height)
-                    {
-                        log.Warning($"Texture budget for layer {layer} cannot be met, no further reduction possible for {candidate.FilePath}");
-                        break;
-                    }
-
-                    long oldPixels = candidate.PixelCount;
+                    long oldPixelCount = candidate.PixelCount;
                     ResizeTrackedTexture(candidate, newWidth, newHeight);
-                    totalPixels -= oldPixels - candidate.PixelCount;
-
-                    index = (index + 1) % candidates.Count;
+                    totalPixels -= oldPixelCount - candidate.PixelCount;
                 }
             }
         }
@@ -169,21 +150,21 @@ namespace AssetBundleConverter
             return cmp != 0 ? cmp : string.Compare(a.FilePath, b.FilePath, StringComparison.Ordinal);
         }
 
-        private static HashSet<TextureLayer> GetLayers(TextureType types)
+        private static TextureLayer GetLayers(TextureType types)
         {
-            var layers = new HashSet<TextureLayer>();
+            TextureLayer layers = 0;
 
             if ((types & (TextureType.MainTex | TextureType.BaseMap)) != 0)
-                layers.Add(TextureLayer.ALBEDO);
+                layers |= TextureLayer.ALBEDO;
 
             if ((types & TextureType.BumpMap) != 0)
-                layers.Add(TextureLayer.NORMAL);
+                layers |= TextureLayer.NORMAL;
 
             if ((types & TextureType.EmissionMap) != 0)
-                layers.Add(TextureLayer.EMISSIVE);
+                layers |= TextureLayer.EMISSIVE;
 
             if ((types & (TextureType.MetallicGlossMap | TextureType.OcclusionMap | TextureType.ParallaxMap | TextureType.SpecGlossMap)) != 0)
-                layers.Add(TextureLayer.OTHER);
+                layers |= TextureLayer.OTHER;
 
             return layers;
         }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/TexturePixelBudgetEnforcer.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/TexturePixelBudgetEnforcer.cs
@@ -1,0 +1,233 @@
+using DCL;
+using DCL.ABConverter;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace AssetBundleConverter
+{
+    internal enum TextureLayer
+    {
+        ALBEDO,
+        NORMAL,
+        EMISSIVE,
+        OTHER,
+    }
+
+    internal sealed class TrackedTexture
+    {
+        public string FilePath;
+        public int Width;
+        public int Height;
+        public long PixelCount => (long)Width * Height;
+        public TextureType Types;
+    }
+
+    public class TexturePixelBudgetEnforcer
+    {
+        // TODO (Maurizio) hard cap?
+
+        private const int PER_PARCEL_MAX_TEXTURE_SIZE = 2048;
+
+        private static readonly TextureLayer[] ALL_LAYERS = (TextureLayer[])Enum.GetValues(typeof(TextureLayer));
+
+        private readonly Dictionary<string, TrackedTexture> trackedTextures = new();
+        private readonly long budgetPerLayer;
+        private readonly IFile file;
+        private readonly IAssetDatabase assetDatabase;
+        private readonly IABLogger log;
+
+        public TexturePixelBudgetEnforcer(int parcelCount, IFile file, IAssetDatabase assetDatabase, IABLogger log)
+        {
+            budgetPerLayer = PER_PARCEL_MAX_TEXTURE_SIZE * PER_PARCEL_MAX_TEXTURE_SIZE * parcelCount;
+            this.file = file;
+            this.assetDatabase = assetDatabase;
+            this.log = log;
+        }
+
+        public void TrackTexture(string filePath, int width, int height, TextureType types)
+        {
+            if (types == TextureType.None)
+                return;
+
+            if (trackedTextures.TryGetValue(filePath, out var existing))
+            {
+                existing.Types |= types;
+                existing.Width = width;
+                existing.Height = height;
+            }
+            else
+                trackedTextures[filePath] = new TrackedTexture
+                {
+                    FilePath = filePath,
+                    Width = width,
+                    Height = height,
+                    Types = types,
+                };
+        }
+
+        public void EnforceBudgets()
+        {
+            foreach (var layer in ALL_LAYERS)
+            {
+                // new
+
+                List<TrackedTexture> candidates = trackedTextures.Values
+                                                .Where(t => GetLayers(t.Types).Contains(layer))
+                                                .ToList();
+
+                if (candidates.Count == 0) continue;
+
+                // Sort by size descending, and same size alphabetically
+                candidates.Sort((a, b) =>
+                {
+                    int cmp = b.PixelCount.CompareTo(a.PixelCount);
+                    return cmp != 0 ? cmp : string.Compare(a.FilePath, b.FilePath, StringComparison.Ordinal); // TODO (Maurizio) is this correct?
+                });
+
+                long totalPixels = candidates.Sum(c => c.PixelCount);
+
+                int index = 0;
+
+                while (totalPixels > budgetPerLayer)
+                {
+                    TrackedTexture candidate = candidates[index];
+
+                    // Knowing that candidates[index + 1] would be same or less size that candidates[index]
+                    // then safely assume this layer cannot be optimized further
+                    if (candidate.Width <= 1 && candidate.Height <= 1)
+                    {
+                        log.Warning($"Texture budget for layer {layer} cannot be met, largest texture already at 1x1");
+                        break;
+                    }
+
+                    long excess = totalPixels - budgetPerLayer;
+                    long currentPixels = candidate.PixelCount;
+                    long targetPixels = Math.Max(1, currentPixels - excess);
+
+                    float factor = Mathf.Sqrt((float)targetPixels / currentPixels);
+
+                    // If factor < 0.5, limit to halving the size, it will continue reducing on next iteration,
+                    // this way not a single pixel of budget is wasted
+                    if (factor < 0.5f)
+                        factor = 0.5f;
+
+                    int newWidth = Mathf.Max(1, (int)(candidate.Width * factor));
+                    int newHeight = Mathf.Max(1, (int)(candidate.Height * factor));
+
+                    if (newWidth == candidate.Width && newHeight == candidate.Height)
+                    {
+                        log.Warning($"Texture budget for layer {layer} cannot be met, no further reduction possible for {candidate.FilePath}");
+                        break;
+                    }
+
+                    long oldPixels = candidate.PixelCount;
+                    ResizeTrackedTexture(candidate, newWidth, newHeight);
+                    totalPixels -= oldPixels - candidate.PixelCount;
+
+                    index = (index + 1) % candidates.Count;
+                }
+
+                // end new
+
+                // var candidates = trackedTextures.Values
+                //     .Where(t => GetLayers(t.Types).Contains(layer))
+                //     .ToList();
+                //
+                // long totalPixels = candidates.Sum(c => c.PixelCount);
+                //
+                // while (totalPixels > budgetPerLayer)
+                // {
+                //     candidates.Sort((a, b) =>
+                //     {
+                //         int cmp = b.PixelCount.CompareTo(a.PixelCount);
+                //         return cmp != 0 ? cmp : string.Compare(a.FilePath, b.FilePath, StringComparison.Ordinal);
+                //     });
+                //
+                //     var largest = candidates[0];
+                //
+                //     if (largest.Width <= 1 && largest.Height <= 1)
+                //     {
+                //         log.Warning($"Texture budget for layer {layer} cannot be met, largest texture already at 1x1");
+                //         break;
+                //     }
+                //
+                //     long excess = totalPixels - budgetPerLayer;
+                //     long currentPixels = largest.PixelCount;
+                //     long targetPixels = Math.Max(1, currentPixels - excess);
+                //
+                //     // targetPixels = w*h*f^2 => f = sqrt(targetPixels / currentPixels)
+                //     float factor = Mathf.Sqrt((float)targetPixels / currentPixels);
+                //
+                //     // If factor < 0.5, only halve — the next iteration will pick
+                //     // the new largest texture and continue reducing
+                //     if (factor < 0.5f)
+                //         factor = 0.5f;
+                //
+                //     int newWidth = Mathf.Max(1, (int)(largest.Width * factor));
+                //     int newHeight = Mathf.Max(1, (int)(largest.Height * factor));
+                //
+                //     if (newWidth == largest.Width && newHeight == largest.Height)
+                //     {
+                //         log.Warning($"Texture budget for layer {layer} cannot be met, no further reduction possible for {largest.FilePath}");
+                //         break;
+                //     }
+                //
+                //     long oldPixels = largest.PixelCount;
+                //     ResizeTrackedTexture(largest, newWidth, newHeight);
+                //     totalPixels -= oldPixels - largest.PixelCount;
+                //}
+            }
+        }
+
+        private void ResizeTrackedTexture(TrackedTexture texture, int newWidth, int newHeight)
+        {
+            byte[] image = file.ReadAllBytes(texture.FilePath);
+
+            var tmpTex = new Texture2D(1, 1);
+
+            if (!tmpTex.LoadImage(image))
+            {
+                Object.DestroyImmediate(tmpTex);
+                log.Error($"Failed to load texture for budget resize: {texture.FilePath}");
+                return;
+            }
+
+            log.Verbose($"Texture budget: resizing {texture.FilePath} from {texture.Width}x{texture.Height} to {newWidth}x{newHeight}");
+
+            Texture2D dstTex = Utils.ResizeTexture(tmpTex, newWidth, newHeight);
+            byte[] resizedBytes = dstTex.EncodeToPNG();
+
+            Object.DestroyImmediate(tmpTex);
+            Object.DestroyImmediate(dstTex);
+
+            file.WriteAllBytes(texture.FilePath, resizedBytes);
+            assetDatabase.ImportAsset(texture.FilePath, ImportAssetOptions.ForceSynchronousImport | ImportAssetOptions.ForceUpdate);
+
+            texture.Width = newWidth;
+            texture.Height = newHeight;
+        }
+
+        private static HashSet<TextureLayer> GetLayers(TextureType types)
+        {
+            var layers = new HashSet<TextureLayer>();
+
+            if ((types & (TextureType.MainTex | TextureType.BaseMap)) != 0)
+                layers.Add(TextureLayer.ALBEDO);
+
+            if ((types & TextureType.BumpMap) != 0)
+                layers.Add(TextureLayer.NORMAL);
+
+            if ((types & TextureType.EmissionMap) != 0)
+                layers.Add(TextureLayer.EMISSIVE);
+
+            if ((types & (TextureType.MetallicGlossMap | TextureType.OcclusionMap | TextureType.ParallaxMap | TextureType.SpecGlossMap)) != 0)
+                layers.Add(TextureLayer.OTHER);
+
+            return layers;
+        }
+    }
+}

--- a/asset-bundle-converter/Assets/AssetBundleConverter/TexturePixelBudgetEnforcer.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/TexturePixelBudgetEnforcer.cs
@@ -91,6 +91,8 @@ namespace AssetBundleConverter
                 {
                     TrackedTexture candidate = candidates[index];
 
+                    log.Verbose($"Texture budget: optimizing {candidate.FilePath}");
+
                     // Knowing that candidates[index + 1] would be same or less size that candidates[index]
                     // then safely assume this layer cannot be optimized further
                     if (candidate.Width <= 1 && candidate.Height <= 1)
@@ -106,7 +108,7 @@ namespace AssetBundleConverter
                     float factor = Mathf.Sqrt((float)targetPixels / currentPixels);
 
                     // If factor < 0.5, limit to halving the size, it will continue reducing on next iteration,
-                    // this way not a single pixel of budget is wasted
+                    // this way we reduce the number of wasted pixels
                     if (factor < 0.5f)
                         factor = 0.5f;
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/TexturePixelBudgetEnforcer.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/TexturePixelBudgetEnforcer.cs
@@ -9,7 +9,7 @@ using Object = UnityEngine.Object;
 
 namespace AssetBundleConverter
 {
-    internal enum TextureLayer
+    public enum TextureLayer
     {
         ALBEDO,
         NORMAL,
@@ -17,9 +17,10 @@ namespace AssetBundleConverter
         OTHER,
     }
 
-    internal sealed class TrackedTexture
+    public class TrackedTexture
     {
         public string FilePath;
+        public string Name;
         public int Width;
         public int Height;
         public long PixelCount => (long)Width * Height;
@@ -34,7 +35,7 @@ namespace AssetBundleConverter
 
         private static readonly TextureLayer[] ALL_LAYERS = (TextureLayer[])Enum.GetValues(typeof(TextureLayer));
 
-        private readonly Dictionary<string, TrackedTexture> trackedTextures = new();
+        protected readonly Dictionary<string, TrackedTexture> trackedTextures = new();
         private readonly long budgetPerLayer;
         private readonly IFile file;
         private readonly IAssetDatabase assetDatabase;
@@ -42,13 +43,13 @@ namespace AssetBundleConverter
 
         public TexturePixelBudgetEnforcer(int parcelCount, IFile file, IAssetDatabase assetDatabase, IABLogger log)
         {
-            budgetPerLayer = PER_PARCEL_MAX_TEXTURE_SIZE * PER_PARCEL_MAX_TEXTURE_SIZE * parcelCount;
+            budgetPerLayer = (long)PER_PARCEL_MAX_TEXTURE_SIZE * PER_PARCEL_MAX_TEXTURE_SIZE * parcelCount;
             this.file = file;
             this.assetDatabase = assetDatabase;
             this.log = log;
         }
 
-        public void TrackTexture(string filePath, int width, int height, TextureType types)
+        public void TrackTexture(string filePath, string name, int width, int height, TextureType types)
         {
             if (types == TextureType.None)
                 return;
@@ -63,6 +64,7 @@ namespace AssetBundleConverter
                 trackedTextures[filePath] = new TrackedTexture
                 {
                     FilePath = filePath,
+                    Name = name,
                     Width = width,
                     Height = height,
                     Types = types,
@@ -73,20 +75,13 @@ namespace AssetBundleConverter
         {
             foreach (var layer in ALL_LAYERS)
             {
-                // new
-
                 List<TrackedTexture> candidates = trackedTextures.Values
                                                 .Where(t => GetLayers(t.Types).Contains(layer))
                                                 .ToList();
 
                 if (candidates.Count == 0) continue;
 
-                // Sort by size descending, and same size alphabetically
-                candidates.Sort((a, b) =>
-                {
-                    int cmp = b.PixelCount.CompareTo(a.PixelCount);
-                    return cmp != 0 ? cmp : string.Compare(a.FilePath, b.FilePath, StringComparison.Ordinal); // TODO (Maurizio) is this correct?
-                });
+                candidates.Sort(CompareTextures);
 
                 long totalPixels = candidates.Sum(c => c.PixelCount);
 
@@ -130,60 +125,10 @@ namespace AssetBundleConverter
 
                     index = (index + 1) % candidates.Count;
                 }
-
-                // end new
-
-                // var candidates = trackedTextures.Values
-                //     .Where(t => GetLayers(t.Types).Contains(layer))
-                //     .ToList();
-                //
-                // long totalPixels = candidates.Sum(c => c.PixelCount);
-                //
-                // while (totalPixels > budgetPerLayer)
-                // {
-                //     candidates.Sort((a, b) =>
-                //     {
-                //         int cmp = b.PixelCount.CompareTo(a.PixelCount);
-                //         return cmp != 0 ? cmp : string.Compare(a.FilePath, b.FilePath, StringComparison.Ordinal);
-                //     });
-                //
-                //     var largest = candidates[0];
-                //
-                //     if (largest.Width <= 1 && largest.Height <= 1)
-                //     {
-                //         log.Warning($"Texture budget for layer {layer} cannot be met, largest texture already at 1x1");
-                //         break;
-                //     }
-                //
-                //     long excess = totalPixels - budgetPerLayer;
-                //     long currentPixels = largest.PixelCount;
-                //     long targetPixels = Math.Max(1, currentPixels - excess);
-                //
-                //     // targetPixels = w*h*f^2 => f = sqrt(targetPixels / currentPixels)
-                //     float factor = Mathf.Sqrt((float)targetPixels / currentPixels);
-                //
-                //     // If factor < 0.5, only halve — the next iteration will pick
-                //     // the new largest texture and continue reducing
-                //     if (factor < 0.5f)
-                //         factor = 0.5f;
-                //
-                //     int newWidth = Mathf.Max(1, (int)(largest.Width * factor));
-                //     int newHeight = Mathf.Max(1, (int)(largest.Height * factor));
-                //
-                //     if (newWidth == largest.Width && newHeight == largest.Height)
-                //     {
-                //         log.Warning($"Texture budget for layer {layer} cannot be met, no further reduction possible for {largest.FilePath}");
-                //         break;
-                //     }
-                //
-                //     long oldPixels = largest.PixelCount;
-                //     ResizeTrackedTexture(largest, newWidth, newHeight);
-                //     totalPixels -= oldPixels - largest.PixelCount;
-                //}
             }
         }
 
-        private void ResizeTrackedTexture(TrackedTexture texture, int newWidth, int newHeight)
+        protected virtual void ResizeTrackedTexture(TrackedTexture texture, int newWidth, int newHeight)
         {
             byte[] image = file.ReadAllBytes(texture.FilePath);
 
@@ -209,6 +154,17 @@ namespace AssetBundleConverter
 
             texture.Width = newWidth;
             texture.Height = newHeight;
+        }
+
+        /// <summary>
+        /// Sort by pixel count descending, then by name, then by full path for determinism.
+        /// </summary>
+        private static int CompareTextures(TrackedTexture a, TrackedTexture b)
+        {
+            int cmp = b.PixelCount.CompareTo(a.PixelCount);
+            if (cmp != 0) return cmp;
+            cmp = string.Compare(a.Name, b.Name, StringComparison.Ordinal);
+            return cmp != 0 ? cmp : string.Compare(a.FilePath, b.FilePath, StringComparison.Ordinal);
         }
 
         private static HashSet<TextureLayer> GetLayers(TextureType types)

--- a/asset-bundle-converter/Assets/AssetBundleConverter/TexturePixelBudgetEnforcer.cs.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/TexturePixelBudgetEnforcer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8bd41508ee07f4b15986cc6020ff8d37


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Introduces a per-layer texture pixel budget system that limits total texture memory usage for scenes based on parcel count.

`TexturePixelBudgetEnforcer` tracks all textures extracted from a scene's GLTFs, grouped by semantic layer (Albedo, Normal, Emissive, Other). After all GLTFs are processed, it enforces a per-layer pixel budget of `2048² × parcelCount`, progressively resizing the largest textures first. The reduction factor is clamped to ≥0.5 per pass to distribute resizing evenly rather than crushing a single texture. For non-scene entities (wearables, emotes), the legacy `ReduceTextureSizeIfNeeded` path is preserved.