### PR TITLE
feat: webGPU compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,9 +69,9 @@ ENV NODE_PATH=$NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules
 ENV PATH=$NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
 
 # Change this value ONLY if we have done breaking changes for every material, doing so is VERY costly
-ENV AB_VERSION=v45
-ENV AB_VERSION_WINDOWS=v46
-ENV AB_VERSION_MAC=v46
+ENV AB_VERSION=v47
+ENV AB_VERSION_WINDOWS=v47
+ENV AB_VERSION_MAC=v47
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ ENV NODE_PATH=$NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules
 ENV PATH=$NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
 
 # Change this value ONLY if we have done breaking changes for every material, doing so is VERY costly
-ENV AB_VERSION=v13
+ENV AB_VERSION=v45
 ENV AB_VERSION_WINDOWS=v46
 ENV AB_VERSION_MAC=v46
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.asmdef
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.asmdef
@@ -17,7 +17,9 @@
         "GUID:5c1ff9bd975acec488150743d53a93ca",
         "GUID:c5ecc461727906345a35491a0440694f",
         "GUID:15fc0a57446b3144c949da3e2b9737a9",
-        "GUID:8c9381414d52c93409d4e7d07e4131cb"
+        "GUID:8c9381414d52c93409d4e7d07e4131cb",
+        "GUID:2b1295b82e69ada49bdda18994e3195f",
+        "GUID:3b0204f1f1e0d294c88846aa4ce4587e"
     ],
     "includePlatforms": [
         "Editor"

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -44,18 +44,18 @@ namespace DCL.ABConverter
 
         private readonly Dictionary<string, string> lowerCaseHashes = new ();
         public ConversionState CurrentState { get; } = new ();
-        private readonly Environment env;
-        private readonly ClientSettings settings;
+        private Environment env;
+        private ClientSettings settings;
         private readonly string finalDownloadedPath;
         private readonly string finalDownloadedAssetDbPath;
-        private readonly List<AssetPath> assetsToMark = new ();
-        private readonly List<GltfImportSettings> gltfToWait = new ();
-        private readonly Dictionary<string, string> contentTable = new ();
-        private readonly Dictionary<string, string> gltfOriginalNames = new ();
-        private readonly Dictionary<string, IGltfImport> gltfImporters = new ();
+        private List<AssetPath> assetsToMark = new ();
+        private List<GltfImportSettings> gltfToWait = new ();
+        private Dictionary<string, string> contentTable = new ();
+        private Dictionary<string, string> gltfOriginalNames = new ();
+        private Dictionary<string, IGltfImport> gltfImporters = new ();
         private string logBuffer;
         private int skippedAssets;
-        private readonly IErrorReporter errorReporter;
+        private IErrorReporter errorReporter;
 
         private double conversionStartupTime;
         private double downloadStartupTime;

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -7,11 +7,8 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using AssetBundleConverter;
 using AssetBundleConverter.Editor;
-using AssetBundleConverter.StaticSceneAssetBundle;
 using AssetBundleConverter.Wrappers.Interfaces;
-using Cysharp.Threading.Tasks;
 using GLTFast;
-using Newtonsoft.Json;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
@@ -47,18 +44,18 @@ namespace DCL.ABConverter
 
         private readonly Dictionary<string, string> lowerCaseHashes = new ();
         public ConversionState CurrentState { get; } = new ();
-        private Environment env;
-        private ClientSettings settings;
+        private readonly Environment env;
+        private readonly ClientSettings settings;
         private readonly string finalDownloadedPath;
         private readonly string finalDownloadedAssetDbPath;
-        private List<AssetPath> assetsToMark = new ();
-        private List<GltfImportSettings> gltfToWait = new ();
-        private Dictionary<string, string> contentTable = new ();
-        private Dictionary<string, string> gltfOriginalNames = new ();
-        private Dictionary<string, IGltfImport> gltfImporters = new ();
+        private readonly List<AssetPath> assetsToMark = new ();
+        private readonly List<GltfImportSettings> gltfToWait = new ();
+        private readonly Dictionary<string, string> contentTable = new ();
+        private readonly Dictionary<string, string> gltfOriginalNames = new ();
+        private readonly Dictionary<string, IGltfImport> gltfImporters = new ();
         private string logBuffer;
         private int skippedAssets;
-        private IErrorReporter errorReporter;
+        private readonly IErrorReporter errorReporter;
 
         private double conversionStartupTime;
         private double downloadStartupTime;
@@ -236,13 +233,7 @@ namespace DCL.ABConverter
             var universalRendererData = Resources.FindObjectsOfTypeAll<UniversalRendererData>().First();
             var rendererDataPath = AssetDatabase.GetAssetPath(universalRendererData);
 
-            universalRendererData.renderingMode = targetPlatform switch
-                                                  {
-                                                      BuildTarget.StandaloneWindows64 or BuildTarget.StandaloneOSX => RenderingMode.ForwardPlus,
-                                                      BuildTarget.WebGL => RenderingMode.Forward,
-                                                      _ => universalRendererData.renderingMode
-                                                  };
-
+            universalRendererData.renderingMode =  RenderingMode.ForwardPlus;
             AssetDatabase.ImportAsset(rendererDataPath);
         }
 
@@ -631,11 +622,7 @@ namespace DCL.ABConverter
             if (entityDTO == null) return AnimationMethod.Legacy;
             if (isWearable) return AnimationMethod.None;
             if (isEmote) return AnimationMethod.Mecanim;
-            if (settings.buildTarget is BuildTarget.StandaloneWindows64 or BuildTarget.StandaloneOSX)
-                return settings.AnimationMethod;
-
-            //WebGL platform fallback is always Legacy
-            return AnimationMethod.Legacy;
+            return settings.AnimationMethod;
         }
 
         private void ExtractEmbedMaterialsFromGltf(List<Texture2D> textures, GltfImportSettings gltf, IGltfImport gltfImport, string gltfUrl)
@@ -857,6 +844,15 @@ namespace DCL.ABConverter
                     env.assetDatabase.ImportAsset(texPath, ImportAssetOptions.ForceSynchronousImport | ImportAssetOptions.ForceUpdate);
 
                     ReduceTextureSizeIfNeeded(texPath, maxTextureSize);
+
+                    var importer = env.assetDatabase.GetImporterAtPath(texPath) as TextureImporter;
+
+                    if (importer != null)
+                    {
+                        TextureUtils.ApplyBuildTargetTextureSettings(importer, settings.buildTarget);
+                        EditorUtility.SetDirty(importer);
+                        env.assetDatabase.ImportAsset(texPath, ImportAssetOptions.ForceSynchronousImport | ImportAssetOptions.ForceUpdate);
+                    }
 
                     newTextures.Add(env.assetDatabase.LoadAssetAtPath<Texture2D>(texPath));
                 }
@@ -1375,10 +1371,11 @@ namespace DCL.ABConverter
 
                     ReduceTextureSizeIfNeeded(finalTexturePath, maxTextureSize);
 
-                    texImporter.crunchedCompression = true;
                     texImporter.textureCompression = TextureImporterCompression.CompressedHQ;
                     texImporter.isReadable = true;
                     texImporter.alphaIsTransparency = true;
+
+                    TextureUtils.ApplyBuildTargetTextureSettings(texImporter, settings.buildTarget);
                     EditorUtility.SetDirty(texImporter);
                 }
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -845,15 +845,6 @@ namespace DCL.ABConverter
 
                     ReduceTextureSizeIfNeeded(texPath, maxTextureSize);
 
-                    var importer = env.assetDatabase.GetImporterAtPath(texPath) as TextureImporter;
-
-                    if (importer != null)
-                    {
-                        TextureUtils.ApplyBuildTargetTextureSettings(importer, settings.buildTarget);
-                        EditorUtility.SetDirty(importer);
-                        env.assetDatabase.ImportAsset(texPath, ImportAssetOptions.ForceSynchronousImport | ImportAssetOptions.ForceUpdate);
-                    }
-
                     newTextures.Add(env.assetDatabase.LoadAssetAtPath<Texture2D>(texPath));
                 }
             }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Editor/CustomGltfImporter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Editor/CustomGltfImporter.cs
@@ -31,14 +31,14 @@ namespace AssetBundleConverter.Editor
     [ScriptedImporter(1, new[] { "gltf", "glb" })]
     public class CustomGltfImporter : GltfImporter
     {
-        [SerializeField] private bool useCustomFileProvider = false;
+        [SerializeField] private bool useCustomFileProvider;
         [SerializeField] public bool useOriginalMaterials;
         [HideInInspector] [SerializeField] private ContentMap[] contentMaps;
         [SerializeField] private string fileRootPath;
         [SerializeField] private string hash;
 
         private Dictionary<string, string> contentTable;
-        private HashSet<string> assetNames = new ();
+        private readonly HashSet<string> assetNames = new ();
         private List<string> textureNames;
         private HashSet<Texture2D> textureHash;
         private Dictionary<Texture2D, List<TexMaterialMap>> texMaterialMap;
@@ -70,12 +70,12 @@ namespace AssetBundleConverter.Editor
             }
             else
             {
-                Debug.LogWarning($"Importing without file provider, there can be errors because of relative path files, please run the pipeline again");
+                Debug.LogWarning("Importing without file provider, there can be errors because of relative path files, please run the pipeline again");
                 return;
             }
 
             if (!useOriginalMaterials)
-                SetupCustomMaterialGenerator(new AssetBundleConverterMaterialGenerator(AssetBundleConverterMaterialGenerator.UseNewShader(EditorUserBuildSettings.activeBuildTarget), EditorUserBuildSettings.activeBuildTarget == BuildTarget.WebGL));
+                SetupCustomMaterialGenerator(new AssetBundleConverterMaterialGenerator());
 
             try
             {
@@ -247,7 +247,7 @@ namespace AssetBundleConverter.Editor
                     if (!tex)
                         continue;
 
-                    maps[$"{rendererSharedMaterial.name}_{propertyName}"] = new TexMaterialMap(rendererSharedMaterial, propertyName, false);
+                    maps[$"{rendererSharedMaterial.name}_{propertyName}"] = new TexMaterialMap(rendererSharedMaterial, propertyName, IsNormalMap(propertyName));
                 }
             }
 
@@ -295,11 +295,12 @@ namespace AssetBundleConverter.Editor
                         TextureImporterType targetImportType = GetTextureImporterType(tImporter, isNormalMap);
                         tImporter.textureType = targetImportType;
 
-                        tImporter.crunchedCompression = true;
                         tImporter.sRGBTexture = !metallics.Contains(tex);
                         tImporter.compressionQuality = 100;
                         tImporter.textureCompression = TextureImporterCompression.CompressedHQ;
                         tImporter.mipmapEnabled = true;
+
+                        TextureUtils.ApplyBuildTargetTextureSettings(tImporter, EditorUserBuildSettings.activeBuildTarget);
 
                         // With this we avoid re-importing this glb as it may contain invalid references to textures
                         EditorUtility.SetDirty(tImporter);
@@ -343,7 +344,7 @@ namespace AssetBundleConverter.Editor
         {
             if (mat == null)
             {
-                Debug.LogError("FATAL!");
+                Debug.LogError("FATAL! Missing Material");
                 return;
             }
 
@@ -457,11 +458,6 @@ namespace AssetBundleConverter.Editor
 
         private static bool IsNormalMap(string propertyName) =>
             propertyName is "_BumpMap" or "normalTexture";
-
-        protected override void CreateTextureAssets(AssetImportContext ctx)
-        {
-            // intended nothingness
-        }
 
         private string PatchInvalidFileNameChars(string fileName)
         {

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Editor/CustomGltfImporter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Editor/CustomGltfImporter.cs
@@ -31,14 +31,14 @@ namespace AssetBundleConverter.Editor
     [ScriptedImporter(1, new[] { "gltf", "glb" })]
     public class CustomGltfImporter : GltfImporter
     {
-        [SerializeField] private bool useCustomFileProvider;
+        [SerializeField] private bool useCustomFileProvider = false;
         [SerializeField] public bool useOriginalMaterials;
         [HideInInspector] [SerializeField] private ContentMap[] contentMaps;
         [SerializeField] private string fileRootPath;
         [SerializeField] private string hash;
 
         private Dictionary<string, string> contentTable;
-        private readonly HashSet<string> assetNames = new ();
+        private HashSet<string> assetNames = new ();
         private List<string> textureNames;
         private HashSet<Texture2D> textureHash;
         private Dictionary<Texture2D, List<TexMaterialMap>> texMaterialMap;
@@ -70,7 +70,7 @@ namespace AssetBundleConverter.Editor
             }
             else
             {
-                Debug.LogWarning("Importing without file provider, there can be errors because of relative path files, please run the pipeline again");
+                Debug.LogWarning($"Importing without file provider, there can be errors because of relative path files, please run the pipeline again");
                 return;
             }
 
@@ -344,7 +344,7 @@ namespace AssetBundleConverter.Editor
         {
             if (mat == null)
             {
-                Debug.LogError("FATAL! Missing Material");
+                Debug.LogError("FATAL!");
                 return;
             }
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
@@ -12,7 +12,7 @@ namespace DCL.ABConverter
 {
     public static class SceneClient
     {
-        private static readonly ABLogger log = new ABLogger("ABConverter.SceneClient");
+        private static ABLogger log = new ABLogger("ABConverter.SceneClient");
 
         public static Environment env;
 

--- a/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
@@ -12,7 +12,7 @@ namespace DCL.ABConverter
 {
     public static class SceneClient
     {
-        private static ABLogger log = new ABLogger("ABConverter.SceneClient");
+        private static readonly ABLogger log = new ABLogger("ABConverter.SceneClient");
 
         public static Environment env;
 
@@ -275,7 +275,7 @@ namespace DCL.ABConverter
             // Target is setup during the commandline argument -buildTarget
             settings.buildTarget = EditorUserBuildSettings.activeBuildTarget;
 
-            settings.BuildPipelineType = settings.buildTarget == BuildTarget.WebGL ? BuildPipelineType.Default : BuildPipelineType.Scriptable;
+            settings.BuildPipelineType = BuildPipelineType.Scriptable;
         }
 
         /// <summary>

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Tests/AssetBundleConverterShould.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Tests/AssetBundleConverterShould.cs
@@ -128,7 +128,7 @@ namespace AssetBundleConverter.Tests
             assetDatabase.Received().ImportAsset(Arg.Is(assetPath.finalPath), Arg.Is(ImportAssetOptions.ForceUpdate));
 
             // Ensure that asset was marked for asset bundle build
-            directory.Received().MarkFolderForAssetBundleBuild(assetPath.finalPath, assetPath.hash);
+            directory.Received().MarkFolderForAssetBundleBuild(assetPath.finalPath, assetPath.hash + PlatformUtils.GetPlatform());
 
             // Ensure that asset bundles are being built
             buildPipeline.Received().BuildAssetBundles(Arg.Any<string>(), Arg.Any<BuildAssetBundleOptions>(), Arg.Any<BuildTarget>());
@@ -195,7 +195,7 @@ namespace AssetBundleConverter.Tests
             gltfImporter.Received().ConfigureImporter(Arg.Any<string>(), Arg.Any<ContentMap[]>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ShaderType>(), Arg.Any<AnimationMethod>());
 
             // Ensure that asset was marked for asset bundle build
-            directory.Received().MarkFolderForAssetBundleBuild(assetPath.finalPath, assetPath.hash);
+            directory.Received().MarkFolderForAssetBundleBuild(assetPath.finalPath, assetPath.hash + PlatformUtils.GetPlatform());
 
             // Ensure that asset bundles are being built
             buildPipeline.Received().BuildAssetBundles(Arg.Any<string>(), Arg.Any<BuildAssetBundleOptions>(), Arg.Any<BuildTarget>());

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
@@ -69,10 +69,14 @@ namespace DCL.ABConverter
                 return "_windows";
             if (currentTarget == BuildTarget.StandaloneOSX)
                 return "_mac";
+
+            if (currentTarget == BuildTarget.WebGL)
+                return "_webgl";
+
             if (Application.platform == RuntimePlatform.LinuxPlayer)
                 return "_linux";
 
-            return ""; //Means we are in WebGL, no extra parameters needed
+            return "";
         }
 
         //This method removes the platform from the path, since they are absolute in the downloaded project
@@ -171,6 +175,26 @@ namespace DCL.ABConverter
 
     public static class TextureUtils
     {
+        /// <summary>
+        ///     Applies build-target-specific texture compression settings.
+        ///     WebGL uses DXT5 non-crunched for texture array compatibility (wearables copy directly without runtime conversion).
+        ///     All other targets use crunched compression.
+        /// </summary>
+        public static void ApplyBuildTargetTextureSettings(TextureImporter importer, BuildTarget buildTarget)
+        {
+            if (buildTarget == BuildTarget.WebGL)
+            {
+                TextureImporterPlatformSettings webglSettings = importer.GetPlatformTextureSettings("WebGL");
+                webglSettings.overridden = true;
+                webglSettings.format = TextureImporterFormat.DXT5;
+                webglSettings.textureCompression = TextureImporterCompression.Compressed;
+                webglSettings.crunchedCompression = false;
+                importer.SetPlatformTextureSettings(webglSettings);
+            }
+            else
+                importer.crunchedCompression = true;
+        }
+
         public static bool IsCompressedFormat(TextureFormat format)
         {
             switch (format)
@@ -495,7 +519,18 @@ namespace DCL.ABConverter
                     {
                         suffix = "_windows";
                         assetBundleName = assetBundleName.Replace("_windows", "");
-                    } else if (assetBundleName.EndsWith("_osx"))
+                    }
+                    else if (assetBundleName.EndsWith("_mac"))
+                    {
+                        suffix = "_mac";
+                        assetBundleName = assetBundleName.Replace("_mac", "");
+                    }
+                    else if (assetBundleName.EndsWith("_webgl"))
+                    {
+                        suffix = "_webgl";
+                        assetBundleName = assetBundleName.Replace("_webgl", "");
+                    }
+                    else if (assetBundleName.EndsWith("_osx"))
                     {
                         suffix = "_osx";
                         assetBundleName = assetBundleName.Replace("_osx", "");

--- a/asset-bundle-converter/Assets/AssetBundleConverter/VisualTests.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/VisualTests.cs
@@ -342,15 +342,13 @@ namespace DCL.ABConverter
                     {
                         if (ClientSettings.shaderType == ShaderType.Dcl)
                         {
-                            material.shader = Shader.Find("DCL/Universal Render Pipeline/Lit");
+                            material.shader = Shader.Find("DCL/Scene");
                         }
                         else
                         {
                             material.shader = Shader.Find("Shader Graphs/glTF-pbrMetallicRoughness");
                         }
 
-                        if (ClientSettings.buildTarget == BuildTarget.WebGL)
-                            SRPBatchingHelper.OptimizeMaterial(material);
                     }
 
                     if (asset is GameObject assetAsGameObject)

--- a/asset-bundle-converter/Assets/AssetBundleConverter/VisualTests.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/VisualTests.cs
@@ -340,15 +340,7 @@ namespace DCL.ABConverter
                 {
                     if (asset is Material material)
                     {
-                        if (ClientSettings.shaderType == ShaderType.Dcl)
-                        {
-                            material.shader = Shader.Find("DCL/Scene");
-                        }
-                        else
-                        {
-                            material.shader = Shader.Find("Shader Graphs/glTF-pbrMetallicRoughness");
-                        }
-
+                        material.shader = Shader.Find("DCL/Scene");
                     }
 
                     if (asset is GameObject assetAsGameObject)

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/AssetBundleConverterMaterialGenerator.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/AssetBundleConverterMaterialGenerator.cs
@@ -1,5 +1,4 @@
-﻿using DCL.GLTFast.Wrappers;
-using DCL.Helpers;
+using DCL.GLTFast.Wrappers;
 using DCL.Shaders;
 using GLTFast;
 using UnityEditor;
@@ -9,36 +8,20 @@ namespace AssetBundleConverter.Wrappers.Implementations.Default
 {
     public class AssetBundleConverterMaterialGenerator : DecentralandMaterialGenerator
     {
-        private readonly bool useSceneShader;
-        private readonly bool isWebGLPlatform;
+        private const string SCENE_SHADER = "DCL/Scene";
 
-        public AssetBundleConverterMaterialGenerator(bool useSceneShader, bool isWebGLPlatform) : base(GetShaderName(useSceneShader))
-        {
-            this.useSceneShader = useSceneShader;
-            this.isWebGLPlatform = isWebGLPlatform;
-        }
-
-        public static bool UseNewShader(BuildTarget buildTarget) =>
-            buildTarget != BuildTarget.WebGL;
-
-        private static string GetShaderName(bool useSceneShader) =>
-            useSceneShader ? "DCL/Scene" : "DCL/Universal Render Pipeline/Lit";
+        public AssetBundleConverterMaterialGenerator() : base(SCENE_SHADER)
+        { }
 
         public override Material GenerateMaterial(int materialIndex, GLTFast.Schema.Material gltfMaterial, IGltfReadable gltf, bool pointsSupport = false)
         {
-            var mat = base.GenerateMaterial(materialIndex, gltfMaterial, gltf, pointsSupport);
+            Material mat = base.GenerateMaterial(materialIndex, gltfMaterial, gltf, pointsSupport);
 
-            if (useSceneShader)
-            {
-                // Enable Forward+ and soft shadows
-                mat.EnableKeyword(ShaderUtils.FW_PLUS);
-                mat.EnableKeyword(ShaderUtils.FW_PLUS_LIGHT_SHADOWS);
-                mat.EnableKeyword(ShaderUtils.FW_PLUS_SHADOWS_CASCADE);
-                mat.EnableKeyword(ShaderUtils.FW_PLUS_SHADOWS_SOFT);
-            }
-
-            if(isWebGLPlatform)
-                SRPBatchingHelper.OptimizeMaterial(mat);
+            // Enable Forward+ and soft shadows
+            mat.EnableKeyword(ShaderUtils.FW_PLUS);
+            mat.EnableKeyword(ShaderUtils.FW_PLUS_LIGHT_SHADOWS);
+            mat.EnableKeyword(ShaderUtils.FW_PLUS_SHADOWS_CASCADE);
+            mat.EnableKeyword(ShaderUtils.FW_PLUS_SHADOWS_SOFT);
 
             return mat;
         }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/DefaultGltfImporter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/DefaultGltfImporter.cs
@@ -5,6 +5,7 @@ using DCL.ABConverter;
 using GLTFast;
 using GLTFast.Logging;
 using GLTFast.Materials;
+using System;
 using System.Collections.Generic;
 using UnityEditor;
 
@@ -13,8 +14,8 @@ namespace AssetBundleConverter.Wrappers.Implementations.Default
     public class DefaultGltfImporter : IGltfImporter
     {
         private readonly ConsoleLogger gltfLogger = new ();
-        private IAssetDatabase assetDatabase;
-        private UninterruptedDeferAgent uninterruptedDeferAgent;
+        private readonly IAssetDatabase assetDatabase;
+        private readonly UninterruptedDeferAgent uninterruptedDeferAgent;
         private IMaterialGenerator getNewMaterialGenerator;
 
         public DefaultGltfImporter(IAssetDatabase assetDatabase)
@@ -25,7 +26,10 @@ namespace AssetBundleConverter.Wrappers.Implementations.Default
 
         public IGltfImport GetImporter(AssetPath filePath, Dictionary<string, string> contentTable, ShaderType shaderType, BuildTarget buildTarget)
         {
-            getNewMaterialGenerator = GetNewMaterialGenerator(shaderType, buildTarget);
+            if (shaderType != ShaderType.Dcl)
+                throw new ArgumentException($"Shader type: {shaderType} cannot be used with this importer, it must be ShaderType.Dcl");
+
+            getNewMaterialGenerator = new AssetBundleConverterMaterialGenerator();
 
             return new GltfImportWrapper(
                 new GltFastFileProvider(filePath.fileRootPath, filePath.hash, contentTable),
@@ -33,11 +37,6 @@ namespace AssetBundleConverter.Wrappers.Implementations.Default
                 getNewMaterialGenerator,
                 gltfLogger);
         }
-
-        private static IMaterialGenerator GetNewMaterialGenerator(ShaderType shaderType, BuildTarget buildTarget) =>
-            shaderType == ShaderType.Dcl
-                ? new AssetBundleConverterMaterialGenerator(AssetBundleConverterMaterialGenerator.UseNewShader(buildTarget), buildTarget == BuildTarget.WebGL)
-                : null;
 
         public bool ConfigureImporter(string relativePath, ContentMap[] contentMap, string fileRootPath, string hash, ShaderType shaderType,
             AnimationMethod animationMethod)

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/DefaultGltfImporter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/DefaultGltfImporter.cs
@@ -14,8 +14,8 @@ namespace AssetBundleConverter.Wrappers.Implementations.Default
     public class DefaultGltfImporter : IGltfImporter
     {
         private readonly ConsoleLogger gltfLogger = new ();
-        private readonly IAssetDatabase assetDatabase;
-        private readonly UninterruptedDeferAgent uninterruptedDeferAgent;
+        private IAssetDatabase assetDatabase;
+        private UninterruptedDeferAgent uninterruptedDeferAgent;
         private IMaterialGenerator getNewMaterialGenerator;
 
         public DefaultGltfImporter(IAssetDatabase assetDatabase)

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/ScriptableBuildPipeline.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Wrappers/Implementations/Default/ScriptableBuildPipeline.cs
@@ -39,22 +39,23 @@ namespace DCL
             EditorSceneManager.SaveOpenScenes();
 
             var buildInput = ContentBuildInterface.GenerateAssetBundleBuilds();
-            // Address by names instead of paths for backwards compatibility.
+            // Address by file names instead of full paths for backwards compatibility.
+            // Fall back to the full path for any asset whose file name is not unique within its bundle —
+            // SBP rejects duplicate internal ids since package 2.4.3.
             for (var i = 0; i < buildInput.Length; i++)
             {
-                //TODO (JUANI) : This is done here beacuse Untiy doesnt allow anymore since 2.4.3 Scriptable pipeline package two objects with the same name in an ABs
-                buildInput[i].addressableNames = buildInput[i].assetNames
-                                                              .Select(path =>
-                                                               {
-                                                                   var fileName = Path.GetFileName(path);
-                                                                   bool keepOriginal =
-                                                                       fileName.Contains("image", StringComparison.OrdinalIgnoreCase)
-                                                                       || fileName.Contains("material", StringComparison.OrdinalIgnoreCase)
-                                                                       || fileName.Contains("DCL_Scene", StringComparison.OrdinalIgnoreCase)
-                                                                       || fileName.Contains("animatorController", StringComparison.OrdinalIgnoreCase);
-                                                                   return keepOriginal ? path : fileName;
-                                                               })
-                                                              .ToArray();
+                var assetNames = buildInput[i].assetNames;
+                var shortNames = assetNames.Select(Path.GetFileName).ToArray();
+
+                var duplicatedNames = shortNames
+                    .GroupBy(n => n, StringComparer.OrdinalIgnoreCase)
+                    .Where(g => g.Count() > 1)
+                    .Select(g => g.Key)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                buildInput[i].addressableNames = assetNames
+                    .Select((path, idx) => duplicatedNames.Contains(shortNames[idx]) ? path : shortNames[idx])
+                    .ToArray();
             }
 
             var group = BuildPipeline.GetBuildTargetGroup(targetPlatform);

--- a/asset-bundle-converter/Assets/UniversalRenderPipelineGlobalSettings.asset
+++ b/asset-bundle-converter/Assets/UniversalRenderPipelineGlobalSettings.asset
@@ -59,9 +59,6 @@ MonoBehaviour:
       - rid: 775107604381958167
       - rid: 775107604381958168
       - rid: 775107604381958169
-      - rid: 7901573593394315267
-      - rid: 7901573593394315268
-      - rid: 7901573593394315269
     m_RuntimeSettings:
       m_List: []
   m_AssetVersion: 8
@@ -229,6 +226,9 @@ MonoBehaviour:
         m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
         m_AutodeskInteractiveTransparent: {fileID: 4800000, guid: 5c81372d981403744adbdda4433c9c11, type: 3}
         m_AutodeskInteractiveMasked: {fileID: 4800000, guid: 80aa867ac363ac043847b06ad71604cd, type: 3}
+        m_TerrainDetailLit: {fileID: 4800000, guid: f6783ab646d374f94b199774402a5144, type: 3}
+        m_TerrainDetailGrassBillboard: {fileID: 4800000, guid: 29868e73b638e48ca99a19ea58c48d90, type: 3}
+        m_TerrainDetailGrass: {fileID: 4800000, guid: e507fdfead5ca47e8b9a768b51c291a1, type: 3}
         m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
         m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
         m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
@@ -244,8 +244,6 @@ MonoBehaviour:
         m_CopyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
         m_CameraMotionVector: {fileID: 4800000, guid: c56b7e0d4c7cb484e959caeeedae9bbf, type: 3}
         m_StencilDeferredPS: {fileID: 4800000, guid: e9155b26e1bc55942a41e518703fe304, type: 3}
-        m_ClusterDeferred: {fileID: 4800000, guid: 222cce62363a44a380c36bf03b392608, type: 3}
-        m_StencilDitherMaskSeedPS: {fileID: 4800000, guid: 8c3ee818f2efa514c889881ccb2e95a2, type: 3}
         m_DBufferClear: {fileID: 4800000, guid: f056d8bd2a1c7e44e9729144b4c70395, type: 3}
     - rid: 775107604381958158
       type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
@@ -348,39 +346,3 @@ MonoBehaviour:
         m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
         m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
         m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
-    - rid: 7901573593394315267
-      type: {class: RenderingDebuggerRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_version: 0
-    - rid: 7901573593394315268
-      type: {class: VrsRenderPipelineRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_TextureComputeShader: {fileID: 7200000, guid: cacb30de6c40c7444bbc78cb0a81fd2a, type: 3}
-        m_VisualizationShader: {fileID: 4800000, guid: 620b55b8040a88d468e94abe55bed5ba, type: 3}
-        m_VisualizationLookupTable:
-          m_Data:
-          - {r: 1, g: 0, b: 0, a: 1}
-          - {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
-          - {r: 1, g: 1, b: 1, a: 1}
-          - {r: 0, g: 1, b: 0, a: 1}
-          - {r: 0.75, g: 0.75, b: 0, a: 1}
-          - {r: 0, g: 0.75, b: 0.55, a: 1}
-          - {r: 0.5, g: 0, b: 0.5, a: 1}
-          - {r: 0.5, g: 0.5, b: 0.5, a: 1}
-          - {r: 0, g: 0, b: 1, a: 1}
-        m_ConversionLookupTable:
-          m_Data:
-          - {r: 1, g: 0, b: 0, a: 1}
-          - {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
-          - {r: 1, g: 1, b: 1, a: 1}
-          - {r: 0, g: 1, b: 0, a: 1}
-          - {r: 0.75, g: 0.75, b: 0, a: 1}
-          - {r: 0, g: 0.75, b: 0.55, a: 1}
-          - {r: 0.5, g: 0, b: 0.5, a: 1}
-          - {r: 0.5, g: 0.5, b: 0.5, a: 1}
-          - {r: 0, g: 0, b: 1, a: 1}
-    - rid: 7901573593394315269
-      type: {class: LightmapSamplingSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_Version: 1
-        m_UseBicubicLightmapSampling: 0

--- a/asset-bundle-converter/Assets/UniversalRenderPipelineGlobalSettings.asset
+++ b/asset-bundle-converter/Assets/UniversalRenderPipelineGlobalSettings.asset
@@ -59,6 +59,9 @@ MonoBehaviour:
       - rid: 775107604381958167
       - rid: 775107604381958168
       - rid: 775107604381958169
+      - rid: 7901573593394315267
+      - rid: 7901573593394315268
+      - rid: 7901573593394315269
     m_RuntimeSettings:
       m_List: []
   m_AssetVersion: 8
@@ -226,9 +229,6 @@ MonoBehaviour:
         m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
         m_AutodeskInteractiveTransparent: {fileID: 4800000, guid: 5c81372d981403744adbdda4433c9c11, type: 3}
         m_AutodeskInteractiveMasked: {fileID: 4800000, guid: 80aa867ac363ac043847b06ad71604cd, type: 3}
-        m_TerrainDetailLit: {fileID: 4800000, guid: f6783ab646d374f94b199774402a5144, type: 3}
-        m_TerrainDetailGrassBillboard: {fileID: 4800000, guid: 29868e73b638e48ca99a19ea58c48d90, type: 3}
-        m_TerrainDetailGrass: {fileID: 4800000, guid: e507fdfead5ca47e8b9a768b51c291a1, type: 3}
         m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
         m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
         m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
@@ -244,6 +244,8 @@ MonoBehaviour:
         m_CopyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
         m_CameraMotionVector: {fileID: 4800000, guid: c56b7e0d4c7cb484e959caeeedae9bbf, type: 3}
         m_StencilDeferredPS: {fileID: 4800000, guid: e9155b26e1bc55942a41e518703fe304, type: 3}
+        m_ClusterDeferred: {fileID: 4800000, guid: 222cce62363a44a380c36bf03b392608, type: 3}
+        m_StencilDitherMaskSeedPS: {fileID: 4800000, guid: 8c3ee818f2efa514c889881ccb2e95a2, type: 3}
         m_DBufferClear: {fileID: 4800000, guid: f056d8bd2a1c7e44e9729144b4c70395, type: 3}
     - rid: 775107604381958158
       type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
@@ -346,3 +348,39 @@ MonoBehaviour:
         m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
         m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
         m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
+    - rid: 7901573593394315267
+      type: {class: RenderingDebuggerRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_version: 0
+    - rid: 7901573593394315268
+      type: {class: VrsRenderPipelineRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_TextureComputeShader: {fileID: 7200000, guid: cacb30de6c40c7444bbc78cb0a81fd2a, type: 3}
+        m_VisualizationShader: {fileID: 4800000, guid: 620b55b8040a88d468e94abe55bed5ba, type: 3}
+        m_VisualizationLookupTable:
+          m_Data:
+          - {r: 1, g: 0, b: 0, a: 1}
+          - {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+          - {r: 1, g: 1, b: 1, a: 1}
+          - {r: 0, g: 1, b: 0, a: 1}
+          - {r: 0.75, g: 0.75, b: 0, a: 1}
+          - {r: 0, g: 0.75, b: 0.55, a: 1}
+          - {r: 0.5, g: 0, b: 0.5, a: 1}
+          - {r: 0.5, g: 0.5, b: 0.5, a: 1}
+          - {r: 0, g: 0, b: 1, a: 1}
+        m_ConversionLookupTable:
+          m_Data:
+          - {r: 1, g: 0, b: 0, a: 1}
+          - {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+          - {r: 1, g: 1, b: 1, a: 1}
+          - {r: 0, g: 1, b: 0, a: 1}
+          - {r: 0.75, g: 0.75, b: 0, a: 1}
+          - {r: 0, g: 0.75, b: 0.55, a: 1}
+          - {r: 0.5, g: 0, b: 0.5, a: 1}
+          - {r: 0.5, g: 0.5, b: 0.5, a: 1}
+          - {r: 0, g: 0, b: 1, a: 1}
+    - rid: 7901573593394315269
+      type: {class: LightmapSamplingSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_Version: 1
+        m_UseBicubicLightmapSampling: 0

--- a/asset-bundle-converter/ProjectSettings/ProjectSettings.asset
+++ b/asset-bundle-converter/ProjectSettings/ProjectSettings.asset
@@ -331,7 +331,7 @@ PlayerSettings:
     m_APIs: 10000000
     m_Automatic: 1
   - m_BuildTarget: WebGLSupport
-    m_APIs: 0b000000
+    m_APIs: 1c000000
     m_Automatic: 0
   m_BuildTargetVRSettings:
   - m_BuildTarget: Standalone


### PR DESCRIPTION
## Summary

Based on https://github.com/decentraland/asset-bundle-converter/pull/242 (code changes only, without Unity version upgrade).

### WebGL/WebGPU Build Target Support
- Added `_webgl` suffix handling for WebGL-targeted asset bundles, alongside the existing `_windows` and `_mac` suffixes
- Applied WebGL-specific texture compression: DXT5 non-crunched format for all textures when building for WebGL, ensuring texture array compatibility for wearables. Crunched compression is disabled on this platform since it is not supported by WebGPU
- `TextureUtils.ApplyBuildTargetTextureSettings` added as a reusable helper encapsulating this logic

### Rendering Pipeline Updates
- WebGL now uses ForwardPlus rendering mode (previously forced to Forward), aligning it with Desktop targets
- `AssetBundleConverterMaterialGenerator` now always uses `DCL/Scene` shader on all platforms (previously excluded WebGL)
- Removed WebGL-specific `SRPBatchingHelper.OptimizeMaterial` calls — no longer needed with WebGPU renderer
- Removed WebGL platform fallback to `AnimationMethod.Legacy` — all platforms now use `settings.AnimationMethod`
- Use Scriptable Build Pipeline for all platforms including WebGL

### Also
- Improved SBP addressable names logic to handle duplicates generically instead of hardcoded name checks
- Simplified `VisualTests.cs` shader assignment to always use `DCL/Scene`
- Updated `unity-gltf` submodule to latest main
- Bumped `AB_VERSION` to v47 for all platforms


🤖 Generated with [Claude Code](https://claude.com/claude-code)