### PR TITLE
fix: correct shouldIgnoreConversion argument order

### DIFF
--- a/consumer-server/src/logic/conversion-task.ts
+++ b/consumer-server/src/logic/conversion-task.ts
@@ -274,7 +274,7 @@ export async function executeConversion(
   }
 
   if (!force) {
-    if (await shouldIgnoreConversion(components, entityId, abVersion, $BUILD_TARGET)) {
+    if (await shouldIgnoreConversion(components, abVersion, entityId, $BUILD_TARGET)) {
       logger.info('Ignoring conversion', { entityId, contentServerUrl, abVersion })
       return 13 // ALREADY_CONVERTED exit code
     }


### PR DESCRIPTION
## Why

The call to `shouldIgnoreConversion` in `executeConversion` has had its 2nd and 3rd arguments swapped since the call site was introduced (commit `86dadd64`, 2025-11-07). The function's dedup check has been silently broken in production ever since — every conversion re-runs even when the output is already cached at the same version.

**Call site** (conversion-task.ts:277, pre-fix):
```ts
shouldIgnoreConversion(components, entityId, abVersion, $BUILD_TARGET)
//                                 ^^^^^^^^  ^^^^^^^^^
//                                 position 2  position 3
```

**Function signature** (conversion-task.ts:110):
```ts
async function shouldIgnoreConversion(
  components: ...,
  $AB_VERSION: string,   // position 2
  entityId: string,      // position 3
  target: string | undefined
)
```

So at runtime:
- The `$AB_VERSION` parameter inside the function is actually bound to the entity ID (a CID like `bafy…`).
- The `entityId` parameter is actually bound to the version string (e.g. `v2004`).

## Downstream effect

Inside `shouldIgnoreConversion`:

```ts
const manifestFile = manifestKeyForEntity(entityId, target)
//                                         ^^^^^^^^
//                                         ← actually the version string
```

So the S3 lookup key becomes something like `manifest/v2004_windows.json` — a key that **never exists** because real manifests are keyed by entity ID (CID), not version.

`cdnS3.getObject` throws `NoSuchKey`, the surrounding `catch {}` swallows it, the function returns `false`. **The dedup check has been a no-op in production**: every conversion fully re-runs regardless of whether the same entity was already converted at the same version moments ago.

## Fix

One-line swap at the call site:

```diff
-    if (await shouldIgnoreConversion(components, entityId, abVersion, $BUILD_TARGET)) {
+    if (await shouldIgnoreConversion(components, abVersion, entityId, $BUILD_TARGET)) {
```

No signature change. The parameter names inside the function body (`entityId` used for the manifest key, `$AB_VERSION` for the version comparison) are already semantically correct — only the call site was wrong.

## Risks

This is a correctness fix for a 5.5-month-old bug, which means downstream systems have been operating in a world where "every SQS message triggers a full Unity conversion" is an invariant. Restoring the dedup is a **behaviorally breaking change** even though it's not a code/API breaking change.

### HIGH — Registry handling of `statusCode: 13` is unverified
`statusCode: 13` (`ALREADY_CONVERTED`) is defined in the code (both the Node-side return and the C# `ErrorCodes` enum at `ErrorCodes.cs:21`) but has **never been emitted in production** because the dedup was broken. The `asset-bundle-registry` consumes every `AssetBundleConversionFinishedEvent` and dispatches on `metadata.statusCode`. If it treats anything non-zero as "failed", we will suddenly start flagging previously-converted entities as FAILED on every duplicate-enqueue.

**Must verify the registry's handler treats 13 as "already done / no-op" before merging.**

### MEDIUM — Manifest-present-but-bundles-missing
The dedup trusts the presence of `manifest/${entityId}_${target}.json` with `exitCode === 0` as a signal that the bundle files are in CDN. If a past conversion wrote the manifest but its `uploadDir` failed partway (manifest present, some bundles missing), the fix would skip re-conversion and leave the CDN in a broken state that would have been healed by the buggy "always re-run" behavior.

Mitigation: the upload order in `executeConversion` writes bundles via `uploadDir` **first**, then overwrites the manifest JSON — so a present manifest usually implies present bundles. But not atomically: if the process died between the two steps, the manifest would be the *previous* run's (so this is fine), or a write succeeded but the bundle list in the manifest includes files that the upload didn't yet ship. Worth confirming the happy path by spot-checking a successful entity's CDN contents after deploy.

### MEDIUM — Metric baselines shift
- `ab_converter_exit_codes{exit_code="13"}` goes from 0 to nonzero.
- `ab_converter_exit_codes{exit_code="0"}` drops (duplicates no longer counted as success).
- Total Unity spawn count drops.
- `ab_converter_running_conversion` gauge peak drops.

Dashboards / alerts keyed on absolute counts (e.g. "total conversions per hour") may fire. Alerts keyed on rate-of-change or error ratios should still work.

### LOW — Extra CDN `getObject` latency per conversion
Every scene conversion now incurs one `cdnS3.getObject` round-trip to check for the existing manifest. ~50-100ms per attempt, negligible compared to a 60+ minute Unity run. Cost is trivial at our volume.

### LOW — Forced conversions still bypass dedup
If `job.force === true`, the dedup check is skipped (see the `if (!force)` guard at line 286). Operators manually re-queueing an entity with `force=true` keeps working exactly as before.

## Rollback

Clean. The fix is a 3-char change (`entityId, abVersion` → `abVersion, entityId`). Revert is a one-line PR, no data migration, no coordinating deploys.

## Impact assessment (expected post-deploy)

- **Before:** dedup always false → every SQS message triggers a full conversion, even if the entity was already converted to the same `$AB_VERSION`. Wasted CPU / GPU / Unity spawn time.
- **After:** dedup returns true when a matching manifest exists with `exitCode === 0` and `version === $AB_VERSION` → duplicate conversions skipped with exit code 13 (`ALREADY_CONVERTED`).

Watch for increased `ab_converter_exit_codes{exit_code="13"}` and decreased total conversion volume after this deploys.

## Test plan

- [ ] **Verify registry handling of `statusCode: 13` before merging.** Read the registry's handler for `AssetBundleConversionFinishedEvent` and confirm it treats 13 as "already done" rather than "failed".
- [ ] Deploy to staging. Re-enqueue an entity that's already in the CDN at the current `$AB_VERSION` — converter should log `"Ignoring conversion"` and return 13 instead of running Unity.
- [ ] Enqueue an entity at a newer `$AB_VERSION` than the cached one — converter should run normally.
- [ ] Enqueue an entity whose previous manifest has a non-zero `exitCode` — converter should run normally (the `if (json.exitCode) return false` branch).
- [ ] Enqueue with `job.force = true` — should bypass dedup and run even if the manifest matches.
- [ ] Watch Grafana for 10-15 min post-deploy:
  - `ab_converter_exit_codes{exit_code="13"}` should go from 0 to nonzero.
  - `ab_converter_exit_codes{exit_code="0"}` rate should drop proportionally to the dedup hit rate.
  - Registry should not show a spike in "failed entity" errors.