### PR TITLE
chore: added more info about assets download status

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -1112,6 +1112,10 @@ namespace DCL.ABConverter
 
                 int totalAssetsToDownload = gltfPaths.Count + bufferPaths.Count + texturePaths.Count;
                 int progress = 0;
+                int logStride = Math.Max(1, totalAssetsToDownload / 10);
+                int lastLoggedProgress = 0;
+
+                log.Info($"Starting download of {totalAssetsToDownload} asset(s) (gltf:{gltfPaths.Count}, buffer:{bufferPaths.Count}, texture:{texturePaths.Count})");
 
                 long GetTotalMegabytesDownloaded() =>
                     downloadedData.Values.Sum(array => array.LongLength) / (1024 * 1024);
@@ -1120,6 +1124,13 @@ namespace DCL.ABConverter
                 {
                     await Task.WhenAll(downloadTasks);
                     log.Verbose($"{nameof(ResolveAssets)}: {progress}/{totalAssetsToDownload}; {GetTotalMegabytesDownloaded()} MB");
+
+                    if (progress - lastLoggedProgress >= logStride || progress == totalAssetsToDownload)
+                    {
+                        log.Info($"Download progress: {progress}/{totalAssetsToDownload} ({totalAssetsToDownload - progress} remaining); {GetTotalMegabytesDownloaded()} MB");
+                        lastLoggedProgress = progress;
+                    }
+
                     downloadTasks.Clear();
                 }
 


### PR DESCRIPTION
When handling big scenes with loads of entities, there weren't any logs indicating the download status, with this PR I've added some additional logs that provide info every 10% of the download like this:

<img width="665" height="157" alt="Screenshot 2026-04-24 at 10 38 37" src="https://github.com/user-attachments/assets/95b1a54e-9b34-4d6b-848f-c2fb1d766ba5" />
