### PR TITLE
fix: glb bundles render textureless after per-glb digest naming

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleMetadataBuilder.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleMetadataBuilder.cs
@@ -50,11 +50,26 @@ namespace DCL.ABConverter
                 }
 
                 string json = JsonUtility.ToJson(metadata);
-                string assetHashName = assetBundles[i];
 
-                hashLowercaseToHashProper.TryGetValue(PlatformUtils.RemovePlatform(assetBundles[i]), out assetHashName);
+                // Composite glb/gltf bundle names are `{hash}_{digest}_{platform}`; legacy /
+                // texture / buffer bundle names are `{hash}_{platform}`. After stripping the
+                // trailing platform suffix the leading underscore-delimited segment is always
+                // the raw asset hash — regardless of whether a per-glb digest is present —
+                // so we slice on the first `_` before looking up the proper-cased hash.
+                // Without this, composite-named bundles silently fail the dictionary lookup
+                // (the `out` overwrites `assetHashName` with `null` on miss), no metadata.json
+                // ever gets written into the asset folder, and the second BuildAssetBundles
+                // pass produces glb bundles with no embedded dependency info — at runtime the
+                // explorer treats them as having zero dependencies, never loads texture
+                // bundles, and renders white materials.
+                string withoutPlatform = PlatformUtils.RemovePlatform(assetBundles[i]);
+                int firstUnderscore = withoutPlatform.IndexOf('_');
+                string lookupKey = firstUnderscore > 0 ? withoutPlatform.Substring(0, firstUnderscore) : withoutPlatform;
 
-                if (!string.IsNullOrEmpty(assetHashName)) { file.WriteAllText(path + $"/{assetHashName}/metadata.json", json); }
+                if (hashLowercaseToHashProper.TryGetValue(lookupKey, out string assetHashName) && !string.IsNullOrEmpty(assetHashName))
+                {
+                    file.WriteAllText(path + $"/{assetHashName}/metadata.json", json);
+                }
             }
         }
     }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Tests/AssetBundleMetadataBuilderShould.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Tests/AssetBundleMetadataBuilderShould.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using AssetBundleConverter.Wrappers.Interfaces;
+using DCL;
+using DCL.ABConverter;
+using NSubstitute;
+using NUnit.Framework;
+using UnityEditor;
+
+namespace AssetBundleConverter.Tests
+{
+    [TestFixture]
+    [Category("EditModeCI")]
+    public class AssetBundleMetadataBuilderShould
+    {
+        private const string OUTPUT_PATH = "Assets/Output";
+        private const string VERSION = "test-version";
+        private const string HASH = "bafkreiaie6ke72c3mfq3w5lhrgw6vy2f4u6kymhd66jxgi7baanyutsira";
+        private const string DIGEST = "5d0481fc69cbe8ec4be5fb899e054043";
+        private const string METADATA_PATH = OUTPUT_PATH + "/" + HASH + "/metadata.json";
+
+        private IFile file;
+        private IAssetBundleManifest manifest;
+        private Dictionary<string, string> hashLowercaseToProper;
+        private BuildTarget previousTarget;
+
+        [SetUp]
+        public void Setup()
+        {
+            // Force a deterministic platform suffix. Edit-mode tests run without an
+            // active build target set, so without this `PlatformUtils.GetPlatform()`
+            // returns "" and the tests can't exercise the platform-suffix-stripping
+            // path that the production bug lives in. We snapshot + restore in
+            // `TearDown` because `currentTarget` is process-wide static state that
+            // bleeds into other fixtures running in the same edit-mode session
+            // (e.g. `AssetBundleConverterShould` reads `GetPlatform()` directly).
+            previousTarget = PlatformUtils.currentTarget;
+            PlatformUtils.currentTarget = BuildTarget.StandaloneOSX;
+
+            file = Substitute.For<IFile>();
+            manifest = Substitute.For<IAssetBundleManifest>();
+            hashLowercaseToProper = new Dictionary<string, string> { { HASH, HASH } };
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            PlatformUtils.currentTarget = previousTarget;
+        }
+
+        [Test]
+        public void WriteMetadataForBareNamedBundles()
+        {
+            var bundleName = HASH + "_mac";
+            manifest.GetAllAssetBundles().Returns(new[] { bundleName });
+            manifest.GetAllDependencies(bundleName).Returns(new string[0]);
+
+            AssetBundleMetadataBuilder.Generate(file, OUTPUT_PATH, hashLowercaseToProper, manifest, VERSION);
+
+            file.Received(1).WriteAllText(METADATA_PATH, Arg.Any<string>());
+        }
+
+        [Test]
+        public void WriteMetadataForCompositeNamedBundles()
+        {
+            // Regression: pre-fix, this case never wrote `metadata.json` because the
+            // dictionary lookup against `{hash}_{digest}` failed (the map is keyed by
+            // raw hash), the `out` parameter overwrote the proper-cased name with null,
+            // and the `IsNullOrEmpty` guard short-circuited the write. Result in
+            // production: glb bundles got rebuilt without embedded dep metadata, and
+            // at runtime the explorer treated them as having zero dependencies — so
+            // textures never loaded and materials rendered as default white.
+            var bundleName = $"{HASH}_{DIGEST}_mac";
+            manifest.GetAllAssetBundles().Returns(new[] { bundleName });
+            manifest.GetAllDependencies(bundleName).Returns(new string[0]);
+
+            AssetBundleMetadataBuilder.Generate(file, OUTPUT_PATH, hashLowercaseToProper, manifest, VERSION);
+
+            file.Received(1).WriteAllText(METADATA_PATH, Arg.Any<string>());
+        }
+
+        [Test]
+        public void SkipBundlesWhoseLeadingHashIsNotInTheLookupMap()
+        {
+            // `_IGNORE`-suffixed shader bundles, generic Unity artifacts, and anything
+            // else whose leading hash isn't in the dictionary should NOT produce a
+            // `metadata.json`: the asset folder named after a proper-cased hash doesn't
+            // exist for them.
+            manifest.GetAllAssetBundles().Returns(new[] { "dcl/scene_ignore_mac" });
+            manifest.GetAllDependencies(Arg.Any<string>()).Returns(new string[0]);
+
+            AssetBundleMetadataBuilder.Generate(file, OUTPUT_PATH, hashLowercaseToProper, manifest, VERSION);
+
+            file.DidNotReceive().WriteAllText(Arg.Any<string>(), Arg.Any<string>());
+        }
+
+        [Test]
+        public void SkipEmptyAndNullBundleNames()
+        {
+            manifest.GetAllAssetBundles().Returns(new[] { "", null });
+
+            AssetBundleMetadataBuilder.Generate(file, OUTPUT_PATH, hashLowercaseToProper, manifest, VERSION);
+
+            file.DidNotReceive().WriteAllText(Arg.Any<string>(), Arg.Any<string>());
+        }
+
+        [Test]
+        public void FilterIgnoreSuffixedDepsOutOfTheDependenciesArray()
+        {
+            // The shared shader bundle is named with the `_IGNORE` token specifically
+            // so the metadata builder strips it from every glb's deps list — the
+            // explorer sources shaders from streaming assets via the `COMMON_SHADERS`
+            // allow-list, not from a per-glb CDN dep fetch.
+            var bundleName = $"{HASH}_{DIGEST}_mac";
+            const string KEPT_DEP = "bafkreitexture_mac";
+            const string FILTERED_DEP = "dcl/scene_IGNORE_mac";
+
+            manifest.GetAllAssetBundles().Returns(new[] { bundleName });
+            manifest.GetAllDependencies(bundleName).Returns(new[] { KEPT_DEP, FILTERED_DEP });
+
+            AssetBundleMetadataBuilder.Generate(file, OUTPUT_PATH, hashLowercaseToProper, manifest, VERSION);
+
+            file.Received(1).WriteAllText(
+                METADATA_PATH,
+                Arg.Is<string>(json => json.Contains(KEPT_DEP) && !json.Contains("IGNORE")));
+        }
+    }
+}

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Tests/AssetBundleMetadataBuilderShould.cs.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Tests/AssetBundleMetadataBuilderShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ed936e56884c4e6992f8af46a2575fa0
+timeCreated: 1777425274

--- a/consumer-server/src/logic/conversion-task.ts
+++ b/consumer-server/src/logic/conversion-task.ts
@@ -676,9 +676,18 @@ export async function executeConversion(
       }
     }
 
+    // Drop the `dcl/` subtree from both the manifest listing and the upload sweep
+    // below. Unity emits a shared shader bundle (`dcl/scene_ignore_mac` and friends —
+    // the `_IGNORE` token comes from `Utils.AssignShaderBundle`) as a side-effect of
+    // bundling glTF materials. The runtime never fetches it from the CDN: the
+    // explorer's `PrepareAssetBundleLoadingParametersSystemBase.COMMON_SHADERS`
+    // allow-list resolves these names to streaming-asset paths embedded in the
+    // client build. Uploading it costs an S3 PUT per scene for bytes nobody reads,
+    // and surfacing the bare `dcl` directory entry from the non-recursive `readdir`
+    // makes the manifest claim "dcl" is a file when it's actually a folder.
     const manifest: Manifest = {
       version: abVersion,
-      files: await promises.readdir(outDirectory),
+      files: (await promises.readdir(outDirectory)).filter((f) => f !== 'dcl'),
       exitCode,
       contentServerUrl,
       date: new Date().toISOString()
@@ -709,6 +718,15 @@ export async function executeConversion(
     await uploadDir(components.cdnS3, cdnBucket, outDirectory, bundleUploadPath, {
       concurrency: 10,
       matches: [
+        {
+          // Skip the shared shader bundle Unity drops here as a build artifact.
+          // `mergeConfiguration` in the cdn-uploader is first-match-wins per key,
+          // so listing this matcher BEFORE the catch-all `**/*` is what makes
+          // `ignore: true` stick — the catch-all still merges into the result
+          // afterwards, but it doesn't override the already-set ignore flag.
+          match: 'dcl/**',
+          ignore: true
+        },
         {
           match: '**/*.manifest',
           contentType: 'text/cache-manifest',

--- a/consumer-server/test/integration/execute-conversion.spec.ts
+++ b/consumer-server/test/integration/execute-conversion.spec.ts
@@ -390,6 +390,146 @@ describe('when executing a conversion with asset-reuse enabled', () => {
     })
   })
 
+  describe('and Unity emits a dcl/ shared shader bundle alongside the scene assets', () => {
+    // Unity bundles the DCL/Scene shader as a side-effect of marking glTF
+    // materials (via `Utils.AssignShaderBundle`'s `_IGNORE` naming). The bundle
+    // name contains a slash so it lands in a `dcl/` subfolder of outDirectory.
+    // The runtime never fetches it from the CDN — the explorer's
+    // `PrepareAssetBundleLoadingParametersSystemBase.COMMON_SHADERS` allow-list
+    // resolves these names to streaming-asset paths embedded in the client. The
+    // converter should therefore skip it from both the upload sweep and the
+    // top-level manifest listing rather than wasting an S3 PUT per scene and
+    // surfacing the bare `dcl` directory entry as if it were a file.
+    let exitCode: number
+    let glbFilename: string
+
+    beforeEach(() => {
+      // Hoisted so the assertion blocks below don't need to re-derive the
+      // composite filename and stay in sync with what the mocked Unity writes.
+      glbFilename = canonicalFilenameForAsset(
+        'hOnlyGlb',
+        '.glb',
+        'windows',
+        new Map([['hOnlyGlb', computeDepsDigest([])]])
+      )
+    })
+
+    describe('and ASSET_REUSE_ENABLED is on (canonical upload prefix)', () => {
+      beforeEach(async () => {
+        mockedGetActiveEntity.mockResolvedValue({
+          id: 'bafy-dcl-skip',
+          type: 'scene',
+          content: [{ file: 'model.glb', hash: 'hOnlyGlb' }],
+          metadata: {}
+        })
+
+        setupFetchMock(new Map([['hOnlyGlb', buildGlb([])]]))
+
+        mockedRunConversion.mockImplementation(async (_l: any, _c: any, options: any) => {
+          await fs.mkdir(path.join(options.outDirectory, 'dcl'), { recursive: true })
+          await fs.writeFile(path.join(options.outDirectory, glbFilename), 'glb-bundle')
+          await fs.writeFile(path.join(options.outDirectory, 'dcl', 'scene_ignore_windows'), 'shader-bytes')
+          return 0
+        })
+
+        exitCode = await executeConversion(
+          components,
+          'bafy-dcl-skip',
+          'https://peer.decentraland.org/content',
+          false,
+          undefined,
+          undefined,
+          'v48'
+        )
+      })
+
+      it('should NOT upload the dcl/ shader bundle to the canonical prefix', async () => {
+        expect(await read(components.cdnS3, 'test-bucket', 'v48/assets/dcl/scene_ignore_windows')).toBeNull()
+      })
+
+      it('should NOT upload the brotli variant of the dcl/ shader bundle either', async () => {
+        expect(await read(components.cdnS3, 'test-bucket', 'v48/assets/dcl/scene_ignore_windows.br')).toBeNull()
+      })
+
+      it('should still list the actual glb bundle in the top-level manifest while omitting the bare dcl directory entry', async () => {
+        // Two-sided assertion to catch over-eager filtering: a bug that drops
+        // legitimate bundles (e.g. a regex matching anything starting with `d`)
+        // would still pass a `not.toContain('dcl')` check but fail this one.
+        const manifest = JSON.parse(
+          (await read(components.cdnS3, 'test-bucket', 'manifest/bafy-dcl-skip_windows.json')) as string
+        )
+        expect(manifest.files).toContain(glbFilename)
+        expect(manifest.files).not.toContain('dcl')
+      })
+
+      it('should still upload the actual glb bundle Unity emitted alongside the dcl/ artifact', async () => {
+        expect(await read(components.cdnS3, 'test-bucket', `v48/assets/${glbFilename}`)).toContain('glb-bundle')
+      })
+
+      it('should return exit code 0 — the dcl skip is invisible to the conversion outcome', () => {
+        expect(exitCode).toBe(0)
+      })
+    })
+
+    describe('and ASSET_REUSE_ENABLED is off (legacy entity-scoped upload prefix)', () => {
+      // Same skip rules apply when the kill switch is off — the matcher lives
+      // in the shared uploadDir block that runs in both modes. A regression
+      // that gates the matcher behind `useAssetReuse` would only surface here.
+      beforeEach(async () => {
+        const off = buildComponents(workDir, { assetReuseEnabled: 'false' })
+        const metrics = await createMetricsComponent(metricDeclarations, { config: off.config })
+        const logs = await createLogComponent({ metrics })
+        components = { ...off, metrics, logs }
+
+        mockedGetActiveEntity.mockResolvedValue({
+          id: 'bafy-dcl-skip-legacy',
+          type: 'scene',
+          content: [{ file: 'model.glb', hash: 'hOnlyGlb' }],
+          metadata: {}
+        })
+
+        mockedRunConversion.mockImplementation(async (_l: any, _c: any, options: any) => {
+          // In legacy mode Unity emits bare `{hash}_{target}` names — no per-glb
+          // digest in the filename — but the dcl/ side artifact is identical.
+          await fs.mkdir(path.join(options.outDirectory, 'dcl'), { recursive: true })
+          await fs.writeFile(path.join(options.outDirectory, 'hOnlyGlb_windows'), 'glb-bundle-legacy')
+          await fs.writeFile(path.join(options.outDirectory, 'dcl', 'scene_ignore_windows'), 'shader-bytes')
+          return 0
+        })
+
+        exitCode = await executeConversion(
+          components,
+          'bafy-dcl-skip-legacy',
+          'https://peer.decentraland.org/content',
+          false,
+          undefined,
+          undefined,
+          'v48'
+        )
+      })
+
+      it('should NOT upload the dcl/ shader bundle to the entity-scoped prefix', async () => {
+        expect(
+          await read(components.cdnS3, 'test-bucket', 'v48/bafy-dcl-skip-legacy/dcl/scene_ignore_windows')
+        ).toBeNull()
+      })
+
+      it('should still upload the actual glb bundle to the entity-scoped prefix', async () => {
+        expect(await read(components.cdnS3, 'test-bucket', 'v48/bafy-dcl-skip-legacy/hOnlyGlb_windows')).toContain(
+          'glb-bundle-legacy'
+        )
+      })
+
+      it('should still list the glb in the manifest while omitting the bare dcl entry', async () => {
+        const manifest = JSON.parse(
+          (await read(components.cdnS3, 'test-bucket', 'manifest/bafy-dcl-skip-legacy_windows.json')) as string
+        )
+        expect(manifest.files).toContain('hOnlyGlb_windows')
+        expect(manifest.files).not.toContain('dcl')
+      })
+    })
+  })
+
   describe('and ASSET_REUSE_ENABLED is off and the canonical prefix is fully populated', () => {
     let exitCode: number
 


### PR DESCRIPTION
## why

scene `bafkreiea2tuhqf4qfid35ordapbuhvzh4eddy2cw6bj6w337qjqccnfmh4` (and every other scene converted on the asset-reuse path since #258) was rendering with all materials defaulting to white in-world. meshes loaded fine — textures never applied. tracing the chain end to end:

- pr #258 renamed glb/gltf bundles from bare `{hash}_{platform}` to composite `{hash}_{digest}_{platform}`. consumer-server probe + unity-side build pipeline (`AssetBundleConverter.cs:937-961`) both got updated.
- `AssetBundleMetadataBuilder.Generate` did not. after stripping the platform suffix it looks up `{hash}_{digest}` in `hashLowercaseToHashProper`, which is keyed by raw hash only. the lookup fails, the `out` parameter overwrites `assetHashName` with `null`, and the `string.IsNullOrEmpty` guard short-circuits the `metadata.json` write.
- result: every composite-named glb bundle is rebuilt by the second `BuildAssetBundles` pass without an embedded `metadata.json`. at runtime the explorer (`LoadAssetBundleSystem.cs:103-113`) reads no metadata and falls through to `dependencies = Array.Empty<AssetBundleData>()` — texture/buffer dep bundles are never loaded, materials render with the default white albedo.

while looking at the same scene's manifest, a separate (smaller) issue:

- the converter uploads a shared shader bundle `dcl/scene_ignore_mac` on every scene. the runtime never fetches it from the cdn — `PrepareAssetBundleLoadingParametersSystemBase.COMMON_SHADERS` resolves these names to streaming-asset paths embedded in the explorer build. so it's a wasted s3 put per scene, and the bare `dcl` directory entry that non-recursive `readdir` surfaces makes the top-level manifest claim a folder is a file.
- on the asset-reuse path the canonical url for it also 404s through the cdn rewriter via the entity-scoped path (rewriter regex doesn't span slashes). harmless today since the runtime never asks for it, but a footgun.

## how

**unity (`asset-bundle-converter/Assets/`):**

- `AssetBundleMetadataBuilder.cs:54-72` — slice the bundle name on the first underscore after `RemovePlatform` to isolate the leading hash. that's the lookup key for both bare and composite names. uses a fresh local for the lookup result so the `out` parameter can't overwrite the previous value with `null` on a miss.
- `Tests/AssetBundleMetadataBuilderShould.cs` — new nunit fixture (`EditModeCI` category). 5 tests: bare-named happy path, composite-named regression, unknown leading hash → no write, null/empty bundle name → no write, `_IGNORE` dep filtering still applies. snapshots/restores `PlatformUtils.currentTarget` to keep the static from bleeding into other fixtures.

**consumer-server (`src/logic/`):**

- `conversion-task.ts:679-694` — filter the bare `dcl` directory entry out of `manifest.files` so the top-level manifest only lists actual bundle filenames.
- `conversion-task.ts:720-729` — prepend an `ignore: true` matcher for `dcl/**` to the `uploadDir` config. `mergeConfiguration` in cdn-uploader is first-match-wins per key, so the later catch-all still merges content-type/variants but doesn't override the ignore flag.
- `test/integration/execute-conversion.spec.ts` — 8 new integration tests covering the dcl skip in both reuse-on (canonical prefix) and reuse-off (legacy entity-scoped prefix) modes, with two-sided manifest assertions (asserts the glb IS in the manifest as well as `dcl` being absent, so an over-eager filter that drops legitimate bundles still fails).
