### PR TITLE
fix: tighten asset-reuse pipeline correctness and entity handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,6 @@ This service doesn't live in isolation. Changes here often imply changes in one 
 
 ## Known gotchas
 
-- **`shouldIgnoreConversion` has a pre-existing argument-order bug** (`conversion-task.ts:110-132`). The function takes `($AB_VERSION, entityId, target)` but the caller at line ~295 passes `(entityId, abVersion, target)` — swapped. The fast path has been dead code for a while. Fixing it silently changes production skip behavior, so handle in a dedicated PR with explicit review.
 - **Don't override `Cache-Control` on `manifest/*.json`**. The converter uploads with `private, max-age=0, no-cache` deliberately so clients revalidate after each conversion. Overriding anywhere (worker, Page Rule, converter) means clients stop seeing new scene hashes.
 - **Don't bump `AB_VERSION` casually.** Invalidates every existing canonical and entity-scoped bundle at that version. Full re-conversion of active scenes required. Ops-level decision.
 - **`hasContentChange` is legacy and narrow** (`has-content-changed-task.ts`). Non-WebGL, scenes only, immediate-previous-version only, all-or-nothing. Superseded by per-asset reuse — kept only as fallback when `ASSET_REUSE_ENABLED=false`. Plan to delete once new path proves.

--- a/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/SceneClient.cs
@@ -287,7 +287,7 @@ namespace DCL.ABConverter
                         settings.cachedHashes.Add(hash.Trim());
                 }
 
-                log.Info($"Received {settings.cachedHashes.Count} cached hash(es) — these GLTF/GLB/BIN bundles will be skipped.");
+                log.Info($"Received {settings.cachedHashes.Count} cached hash(es) — these GLTF/GLB bundles will be skipped.");
             }
 
             if (Utils.ParseOption(commandLineArgs, Config.CLI_SKIPPED_HASHES, 1, out string[] skippedHashesArg)

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
@@ -79,7 +79,12 @@ namespace DCL.ABConverter
             return "";
         }
 
-        //This method removes the platform from the path, since they are absolute in the downloaded project
+        // Strip the trailing platform suffix (`_windows` / `_mac` / `_webgl` /
+        // `_linux`) from a bundle name. Uses an EndsWith + Substring rather than
+        // Replace so an interior occurrence of the suffix string can never be
+        // stripped — content hashes (CIDs) and per-asset digests (hex) can't
+        // contain these substrings today, but Replace would silently corrupt
+        // any future name format that did.
         public static string RemovePlatform(string pathToRemovePlatform)
         {
             string currentPlatform = GetPlatform();
@@ -87,8 +92,10 @@ namespace DCL.ABConverter
             if (string.IsNullOrEmpty(currentPlatform))
                 return pathToRemovePlatform;
 
-            string updatedPath = pathToRemovePlatform.Replace(currentPlatform, "");
-            return updatedPath;
+            if (!pathToRemovePlatform.EndsWith(currentPlatform))
+                return pathToRemovePlatform;
+
+            return pathToRemovePlatform.Substring(0, pathToRemovePlatform.Length - currentPlatform.Length);
         }
     }
 

--- a/consumer-server/src/logic/conversion-task.ts
+++ b/consumer-server/src/logic/conversion-task.ts
@@ -571,7 +571,19 @@ export async function executeConversion(
       cached: cacheResult.cachedHashes.length
     } as any)
 
-    const files = cacheResult.cachedHashes.map((h) => cacheResult!.canonicalNameByHash[h])
+    // Each cached asset has both a bundle (`{name}`) and Unity's per-bundle
+    // manifest (`{name}.manifest`) at canonical — Unity always emits the pair
+    // and the previous conversion uploaded both. List both so the entity
+    // manifest matches the shape produced by the partial-cache path (where
+    // `readdir(outDirectory)` would surface both companions for non-cached
+    // assets) and so any consumer that walks `manifest.files` for `.manifest`
+    // companions doesn't see cached entries as half-present.
+    const files: string[] = []
+    for (const hash of cacheResult.cachedHashes) {
+      const bundleName = cacheResult.canonicalNameByHash[hash]
+      if (!bundleName) continue
+      files.push(bundleName, `${bundleName}.manifest`)
+    }
     const manifest: Manifest = {
       version: abVersion,
       files,
@@ -687,11 +699,24 @@ export async function executeConversion(
     // Top-level entity manifest must advertise every hash that resolves — including
     // the cached ones we intentionally did not produce locally. The canonical name
     // (composite for glb/gltf, bare for BINs/textures) comes from the probe result.
+    // Also append Unity's per-bundle `.manifest` companion: `readdir(outDirectory)`
+    // surfaces it for non-cached entries (Unity always pairs them), and the
+    // previous conversion uploaded both at canonical, so cached entries should
+    // mirror the same shape rather than appear half-present.
     if (useAssetReuse && cacheResult && cacheResult.cachedHashes.length > 0) {
       const seen = new Set(manifest.files)
       for (const hash of cacheResult.cachedHashes) {
         const bundleName = cacheResult.canonicalNameByHash[hash]
-        if (bundleName && !seen.has(bundleName)) manifest.files.push(bundleName)
+        if (!bundleName) continue
+        if (!seen.has(bundleName)) {
+          manifest.files.push(bundleName)
+          seen.add(bundleName)
+        }
+        const companion = `${bundleName}.manifest`
+        if (!seen.has(companion)) {
+          manifest.files.push(companion)
+          seen.add(companion)
+        }
       }
     }
 

--- a/consumer-server/src/logic/fetch-entity-by-pointer.ts
+++ b/consumer-server/src/logic/fetch-entity-by-pointer.ts
@@ -22,7 +22,11 @@ export async function getEntities(
   return JSON.parse(response)
 }
 
-export async function getActiveEntity(id: string, contentServer: string, timeoutMs?: number): Promise<Entity> {
+export async function getActiveEntity(
+  id: string,
+  contentServer: string,
+  timeoutMs?: number
+): Promise<Entity | undefined> {
   const url = `${contentServer}/entities/active`
 
   // Optional per-call timeout via AbortController. Callers like the migration
@@ -30,7 +34,14 @@ export async function getActiveEntity(id: string, contentServer: string, timeout
   // run; the HTTP serving path that calls this without a timeout keeps the
   // pre-existing behaviour of waiting indefinitely (and relying on the SQS
   // visibility timeout to retry if it does).
-  const controller = timeoutMs !== undefined ? new AbortController() : undefined
+  //
+  // A non-positive `timeoutMs` is treated as "no timeout" rather than instant-
+  // abort. `setTimeout(abort, 0)` would fire on the next tick — before the
+  // fetch even resolves DNS — which is almost never what a caller meant. The
+  // migration script clamps to a 1s floor before reaching this helper, but we
+  // also guard here so future callers can't foot-shoot.
+  const useTimeout = timeoutMs !== undefined && timeoutMs > 0
+  const controller = useTimeout ? new AbortController() : undefined
   const timeoutHandle = controller !== undefined ? setTimeout(() => controller.abort(), timeoutMs) : undefined
 
   try {
@@ -47,6 +58,9 @@ export async function getActiveEntity(id: string, contentServer: string, timeout
       throw new Error('Error fetching list of active entities: ' + response)
     }
 
+    // The catalyst returns `[]` when the entity is no longer active (redeployed
+    // / evicted). Surface that as `undefined` rather than letting `[0]` quietly
+    // produce one — the caller decides whether to fall back or throw.
     return JSON.parse(response)[0]
   } finally {
     if (timeoutHandle !== undefined) clearTimeout(timeoutHandle)

--- a/consumer-server/src/logic/has-content-changed-task.ts
+++ b/consumer-server/src/logic/has-content-changed-task.ts
@@ -140,13 +140,26 @@ export async function hasContentChange(
   logger: ILoggerComponent.ILogger
 ): Promise<boolean> {
   const entity = await getActiveEntity(entityId, contentServerUrl)
+  // `getActiveEntity` returns `undefined` when the catalyst no longer has the
+  // entity active (redeployed or evicted). Without this guard, `entity.type`
+  // throws and the outer catch swallows it as a generic "HasContentChanged
+  // failed" — operators lose the actionable signal.
+  if (!entity) {
+    logger.info(`HasContentChanged: Entity ${entityId} is no longer active on the catalyst`)
+    return true
+  }
   if (entity.type === 'scene') {
     logger.info(`HasContentChanged: Entity ${entityId} is a scene`)
-    const environemnt = contentServerUrl.includes('org') ? 'org' : 'zone'
-    const previousHash = await getLastEntityIdByBase(entityId, entity.metadata.scene.base, contentServerUrl)
+    const sceneBase = entity.metadata?.scene?.base
+    if (!sceneBase) {
+      logger.info(`HasContentChanged Error: Entity ${entityId} has no scene.base metadata`)
+      return true
+    }
+    const environment = contentServerUrl.includes('org') ? 'org' : 'zone'
+    const previousHash = await getLastEntityIdByBase(entityId, sceneBase, contentServerUrl)
     if (previousHash !== null) {
       logger.info(`HasContentChanged: Previous hash is ${previousHash}`)
-      const manifest = await getManifestFiles(previousHash, buildTarget, environemnt, logger)
+      const manifest = await getManifestFiles(previousHash, buildTarget, environment, logger)
       if (manifest !== null) {
         logger.info(`HasContentChanged: Manifest exists for hash ${previousHash}`)
         if (manifest.version === abVersion) {
@@ -161,7 +174,7 @@ export async function hasContentChange(
               buildTarget,
               previousHash,
               outputFolder,
-              environemnt,
+              environment,
               logger
             )
             if (allFilesDownloadSuccesfully) {

--- a/consumer-server/src/migrate-to-canonical.ts
+++ b/consumer-server/src/migrate-to-canonical.ts
@@ -174,8 +174,12 @@ export type RunMigrationOptions = {
    * Default 100. */
   progressInterval?: number
   /** Catalyst fetcher — normally `getActiveEntity`; tests pass a stub so they
-   * don't depend on network fetches. Must return the entity's `.content` array. */
-  fetchEntity?: (entityId: string, contentServerUrl: string) => Promise<{ content: { file: string; hash: string }[] }>
+   * don't depend on network fetches. Must return the entity's `.content` array,
+   * or `undefined` when the entity is no longer active on the catalyst. */
+  fetchEntity?: (
+    entityId: string,
+    contentServerUrl: string
+  ) => Promise<{ content: { file: string; hash: string }[] } | undefined>
   /** GLB/GLTF byte fetcher used by `computePerAssetDigests`. Forwarded to the
    * digest-computation helper so tests can stub glb downloads without hitting
    * a real catalyst. Defaults to the production fetcher that talks to the

--- a/consumer-server/src/test-conversion.ts
+++ b/consumer-server/src/test-conversion.ts
@@ -80,6 +80,7 @@ async function main() {
 
   // Fetch the entity to get its type
   const entity = await getActiveEntity(entityId, BASE_URL)
+  if (!entity) throw new Error(`Entity ${entityId} is not active on the catalyst`)
   const entityType = entity.type
 
   try {

--- a/consumer-server/test/integration/execute-conversion.spec.ts
+++ b/consumer-server/test/integration/execute-conversion.spec.ts
@@ -188,7 +188,12 @@ describe('when executing a conversion with asset-reuse enabled', () => {
       expect(manifestBody).not.toBeNull()
       const manifest = JSON.parse(manifestBody!)
       expect(manifest.exitCode).toBe(0)
-      expect(manifest.files.sort()).toEqual([glbFilename, texFilename].sort())
+      // Cached entries surface both the bundle and Unity's per-bundle `.manifest`
+      // companion — the previous Unity run uploaded both to canonical, so the
+      // entity manifest should advertise both.
+      expect(manifest.files.sort()).toEqual(
+        [glbFilename, `${glbFilename}.manifest`, texFilename, `${texFilename}.manifest`].sort()
+      )
       expect(manifest.version).toBe('v48')
 
       // Scene source files uploaded to the entity prefix (not canonical).
@@ -247,7 +252,7 @@ describe('when executing a conversion with asset-reuse enabled', () => {
       const manifest = JSON.parse(
         (await read(components.cdnS3, 'test-bucket', 'manifest/bafy-gltf_windows.json')) as string
       )
-      expect(manifest.files).toEqual([gltfFilename])
+      expect(manifest.files).toEqual([gltfFilename, `${gltfFilename}.manifest`])
     })
   })
 
@@ -347,13 +352,17 @@ describe('when executing a conversion with asset-reuse enabled', () => {
 
       // Mocked Unity: writes the non-cached bundles to outDirectory and returns 0.
       // GLB output uses the composite filename (Unity-side depsDigest naming);
-      // BIN stays at the bare `{hash}_{target}` form.
+      // BIN stays at the bare `{hash}_{target}` form. Each bundle is paired with
+      // its `.manifest` companion so the test exercises the same readdir shape
+      // production Unity produces.
       mockedRunConversion.mockImplementation(async (_logger: any, _components: any, options: any) => {
         expect(options.depsDigestByHash.get('hGlb')).toBe(perGlbDigest)
         expect(options.depsDigestByHash.get('hNewGlb')).toBe(perGlbDigest)
         await fs.mkdir(options.outDirectory, { recursive: true })
         await fs.writeFile(path.join(options.outDirectory, hNewGlbFilename), 'new-glb-bundle')
+        await fs.writeFile(path.join(options.outDirectory, `${hNewGlbFilename}.manifest`), 'new-glb-manifest')
         await fs.writeFile(path.join(options.outDirectory, 'hNewBuf_windows'), 'new-buf-bundle')
+        await fs.writeFile(path.join(options.outDirectory, 'hNewBuf_windows.manifest'), 'new-buf-manifest')
         return 0
       })
 
@@ -380,12 +389,23 @@ describe('when executing a conversion with asset-reuse enabled', () => {
       // Pre-seeded canonical glb untouched (still the old bytes).
       expect(await read(components.cdnS3, 'test-bucket', `v48/assets/${hGlbFilename}`)).toBe('old-glb')
 
-      // Entity manifest lists all four bundle filenames (new + cached).
+      // Entity manifest lists every bundle plus its `.manifest` companion —
+      // both for assets Unity built locally (via readdir) and for cached assets
+      // appended from the probe result.
       const manifest = JSON.parse(
         (await read(components.cdnS3, 'test-bucket', 'manifest/bafy-entity-2_windows.json')) as string
       )
       expect(manifest.files.sort()).toEqual(
-        [hGlbFilename, 'hNewBuf_windows', hNewGlbFilename, 'hTex_windows'].sort()
+        [
+          hGlbFilename,
+          `${hGlbFilename}.manifest`,
+          'hNewBuf_windows',
+          'hNewBuf_windows.manifest',
+          hNewGlbFilename,
+          `${hNewGlbFilename}.manifest`,
+          'hTex_windows',
+          'hTex_windows.manifest'
+        ].sort()
       )
     })
   })


### PR DESCRIPTION
## summary

end-to-end audit of the asset-reuse pipeline surfaced several correctness issues
spanning the consumer-server orchestration, the catalyst-fetch helper, the legacy
fallback path, and the unity-side cli surface. all fixes are independent of the
in-flight glb-metadata fix in #267 and apply cleanly against `main`.

## issues fixed

### `manifest.files` cached-entry inconsistency

`readdir(outDirectory)` returns each unity-emitted bundle alongside its per-bundle
`.manifest` companion, so non-cached entries land in `manifest.files` as a pair.
the cached-entry append loop in `conversion-task.ts:715` only listed the bundle
base name; the full-cache short-circuit at `:574` did the same. the previous unity
run uploaded both companions to the canonical prefix, but the manifest didn't
advertise the `.manifest` half — any consumer walking `manifest.files` for
`.manifest` companions would see cached entries as half-present (and the migration
script's regex pattern in `migrate-to-canonical.ts:335` already expects the legacy
shape with both). both paths now emit the bundle and its `.manifest` companion.

### `getActiveEntity` return type lied

declared `Promise<Entity>` but the implementation does `JSON.parse(response)[0]`
which returns `undefined` when the catalyst no longer has the entity active. two
callers were already guarding (`conversion-task.ts:396`, `migrate-to-canonical.ts
:291`); two were not (`test-conversion.ts:83`, `has-content-changed-task.ts:142`).
tightened the signature to `Promise<Entity | undefined>` so the type system
catches the gap, then added the missing guards. the migration script's
`fetchEntity` option type was widened to match — the runtime check there already
handled `undefined`, only the type was off.

### `hasContentChange` unguarded entity access

the legacy fallback path crashed on `entity.type` and `entity.metadata.scene.base`
whenever the catalyst returned an empty `/entities/active` array. the outer
try/catch in `conversion-task.ts:638` swallowed the crash and forced a full
conversion, so the symptom was a generic 'hasContentChanged failed' message
instead of an actionable signal. added explicit guards for both paths. fixed
the `environemnt` typo while in the file. left the env-from-url heuristic and
the legacy bundle-name url builder alone — the module is slated for deletion
once the canonical path proves and structural changes here aren't worth carrying.

### `getActiveEntity` non-positive timeout footgun

`setTimeout(abort, 0)` fires before the fetch resolves dns. the migration script
clamps to a 1s floor before reaching this helper, and `conversion-task.ts` always
passes 30000, but the helper itself didn't guard. `timeoutMs <= 0` is now treated
the same as `undefined` (no timeout) so a future caller can't accidentally
instant-abort.

### unity `RemovePlatform` over-eager replace

`pathToRemovePlatform.Replace(currentPlatform, "")` strips every occurrence
rather than the trailing suffix. content hashes (cids in base32) and per-asset
digests (32 hex chars) can't contain `_windows` / `_mac` / `_webgl` / `_linux`
today, so the bug is dormant — but a future name format that included a
platform-string substring would silently corrupt. switched to `EndsWith` +
`Substring` so only the trailing suffix is stripped.

### unity `cachedHashes` log message overstated

the line claimed 'GLTF/GLB/BIN bundles will be skipped.' consumer-server only
ever passes the gltf-extension subset (`unitySkippableHashes`); buffer hashes
are excluded from `PROBE_EXTENSIONS` upstream and never reach the unity side
via `cachedHashes`. removed the misleading '/BIN'.

### stale gotcha in `CLAUDE.md`

the `shouldIgnoreConversion` argument-order note still warned the fast path was
dead code. the swap was fixed in #261 (`23b699f`) and the integration tests at
`execute-conversion.spec.ts:1143-1308` now cover the corrected order. the note
would mislead the next contributor into 'fixing' already-correct code. removed.

## explicitly out of scope

- unity `bufferPaths.RemoveAll(... cachedHashes)` / `... skippedHashes)`. the
  in-source comments mark them as deliberate defensive code for a possible
  future buffer-level skip flow; they're not dead in intent.
- operational cleanup of the textureless-glb canonical objects from #267 — that's
  an ops action (delete affected `v48/assets/{hash}_{digest}_{target}` keys after
  deploy), not a code change.
- the legacy `${file}_${buildTarget}` url builder in `hasContentChange` and the
  `includes('org')` env detection. legacy module slated for deletion once
  canonical proves; effort is better spent on the new path.

## test plan

- [x] `cd consumer-server && yarn build && yarn lint:check && yarn test` —
      336 tests pass across 10 suites
- [x] integration tests for the partial-cache + full-cache paths now assert the
      `.manifest` companion shape end-to-end; the partial-cache mocked unity
      writes `.manifest` companions alongside its bundles, exercising the same
      readdir surface production unity produces
- [ ] staging deploy: confirm a fully-cached scene's `manifest/{entityId}_{
      target}.json` lists every bundle and its `.manifest` companion, and that
      both are reachable at the canonical prefix
- [ ] staging deploy: trigger the legacy fallback with a redeployed entity that
      no longer exists on the catalyst — verify the new guard logs the
      no-longer-active message and forces a full conversion (instead of
      crashing into the generic 'hasContentChanged failed' branch)