### PR TITLE
fix: skip cache probe on force=true so Unity reconverts every asset

### DIFF
--- a/consumer-server/src/logic/conversion-task.ts
+++ b/consumer-server/src/logic/conversion-task.ts
@@ -399,21 +399,17 @@ export async function executeConversion(
     logger.info(`Could not fetch entity for ${entityId}: ${e?.message ?? e}. Scene manifest wont be generated`)
   }
 
-  // Per-asset reuse: scenes with the kill switch on and no force/ISS short-circuit
+  // Per-asset reuse: scenes with the kill switch on and no ISS short-circuit
   // the pipeline when every asset hash is already canonicalized at
   // `{abVersion}/assets/{hash}_{target}`. Partial hits feed Unity a `-cachedHashes`
   // list so it skips re-converting those GLTFs/buffers. Rollout is staged per build
   // target via the kill switch (each worker pool runs a single target).
   //
-  // NOTE on force=true: this path uploads to the entity-scoped prefix, NOT
-  // canonical. `force` is for "re-run Unity against this entity's content,"
-  // which for content-addressed immutable storage doesn't translate to
-  // replacing the canonical bundle — the content hash is the same, so the
-  // canonical bundle is by construction the same bytes. If ops need to replace
-  // a canonical bundle (e.g. to flush a genuinely corrupt object), the escape
-  // hatch is to delete the canonical S3 object directly; the next conversion
-  // will upload a fresh copy through the normal reuse path.
-  const useAssetReuse = $ASSET_REUSE_ENABLED && !force && !doISS && entityType === 'scene' && !!entity
+  // `force` keeps `useAssetReuse` true (so canonical uploads still happen and
+  // overwrite the existing canonical bytes — the operator's intent when
+  // re-queuing a scene with bad bundles), but the cache probe below is skipped
+  // so `cachedHashes` stays empty and Unity reconverts every asset.
+  const useAssetReuse = $ASSET_REUSE_ENABLED && !doISS && entityType === 'scene' && !!entity
   const assetReuseUploadPath = abVersion + '/assets'
   const entityScopedUploadPath = abVersion + '/' + entityId
 
@@ -535,7 +531,7 @@ export async function executeConversion(
 
   let cacheResult: AssetCacheResult | null = null
   let fullCacheHit = false
-  if (useAssetReuse && entity) {
+  if (useAssetReuse && entity && !force) {
     try {
       cacheResult = await checkAssetCache(components, {
         entity,
@@ -556,9 +552,9 @@ export async function executeConversion(
     }
   }
 
-  // `fullCacheHit` is only set true inside the `if (useAssetReuse && entity)`
-  // block above, so it already implies `useAssetReuse` AND `!!entity`. The
-  // `cacheResult` and `entity` checks below are kept purely as TypeScript
+  // `fullCacheHit` is only set true inside the `if (useAssetReuse && entity && !force)`
+  // block above, so it already implies `useAssetReuse`, `!!entity`, and `!force`.
+  // The `cacheResult` and `entity` checks below are kept purely as TypeScript
   // narrowing guards for the block body.
   if (fullCacheHit && cacheResult && entity) {
     // Full short-circuit: every referenced asset hash is already canonical. Publish

--- a/consumer-server/test/integration/execute-conversion.spec.ts
+++ b/consumer-server/test/integration/execute-conversion.spec.ts
@@ -514,6 +514,83 @@ describe('when executing a conversion with asset-reuse enabled', () => {
     })
   })
 
+  describe('and force=true and the canonical prefix is partially populated', () => {
+    // Documents that force skips the cache probe wholesale — partial pre-existing
+    // canonical state (one asset cached, one missing) does NOT translate to
+    // partial cachedHashes for Unity. The probe never runs, cacheResult stays
+    // null, every asset is reconverted.
+    let exitCode: number
+    let cachedGlbFilename: string
+    let missingGlbFilename: string
+
+    beforeEach(async () => {
+      const content = [
+        { file: 'cached.glb', hash: 'hCachedGlb' },
+        { file: 'missing.glb', hash: 'hMissingGlb' }
+      ]
+      setupFetchMock(
+        new Map([
+          ['hCachedGlb', buildGlb([], [])],
+          ['hMissingGlb', buildGlb([], [])]
+        ])
+      )
+      const digest = computeDepsDigest([])
+      const digests = new Map([
+        ['hCachedGlb', digest],
+        ['hMissingGlb', digest]
+      ])
+      cachedGlbFilename = canonicalFilenameForAsset('hCachedGlb', '.glb', 'windows', digests)
+      missingGlbFilename = canonicalFilenameForAsset('hMissingGlb', '.glb', 'windows', digests)
+
+      // Seed canonical for ONE of the two assets. Without force, the probe
+      // would classify hCachedGlb as cached and hMissingGlb as missing; force
+      // must short-circuit that distinction.
+      await components.cdnS3
+        .putObject({ Bucket: 'test-bucket', Key: `v48/assets/${cachedGlbFilename}`, Body: 'stale-cached' })
+        .promise()
+
+      mockedGetActiveEntity.mockResolvedValue({
+        id: 'bafy-force-partial',
+        type: 'scene',
+        content,
+        metadata: {}
+      })
+
+      mockedRunConversion.mockImplementation(async (_l: any, _c: any, options: any) => {
+        await fs.mkdir(options.outDirectory, { recursive: true })
+        await fs.writeFile(path.join(options.outDirectory, cachedGlbFilename), 'fresh-cached')
+        await fs.writeFile(path.join(options.outDirectory, missingGlbFilename), 'fresh-missing')
+        return 0
+      })
+
+      exitCode = await executeConversion(
+        components,
+        'bafy-force-partial',
+        'https://peer.decentraland.org/content',
+        /* force */ true,
+        undefined,
+        undefined,
+        'v48'
+      )
+    })
+
+    it('should return exit code 0', () => {
+      expect(exitCode).toBe(0)
+    })
+
+    it('should not pass cachedHashes to Unity even though one asset would have matched', () => {
+      expect(mockedRunConversion.mock.calls[0][2].cachedHashes).toBeUndefined()
+    })
+
+    it('should overwrite the pre-existing canonical bytes for the would-have-been-cached asset', async () => {
+      expect(await read(components.cdnS3, 'test-bucket', `v48/assets/${cachedGlbFilename}`)).toBe('fresh-cached')
+    })
+
+    it('should upload fresh canonical bytes for the previously-missing asset', async () => {
+      expect(await read(components.cdnS3, 'test-bucket', `v48/assets/${missingGlbFilename}`)).toBe('fresh-missing')
+    })
+  })
+
   describe('and doISS=true and the canonical prefix is fully populated', () => {
     let exitCode: number
 

--- a/consumer-server/test/integration/execute-conversion.spec.ts
+++ b/consumer-server/test/integration/execute-conversion.spec.ts
@@ -456,24 +456,33 @@ describe('when executing a conversion with asset-reuse enabled', () => {
 
   describe('and force=true and the canonical prefix is fully populated', () => {
     let exitCode: number
+    let composedGlbFilename: string
 
     beforeEach(async () => {
-      // Seed canonical for every hash in the scene — this is the full-cache
-      // short-circuit scenario. With force=true, that must be bypassed.
+      // force=true skips the cache probe so Unity reconverts every asset and
+      // overwrites the existing canonical bytes — the operator's intent when
+      // re-queuing a scene with bad bundles.
+      const content = [{ file: 'model.glb', hash: 'hGlb' }]
+      setupFetchMock(new Map([['hGlb', buildGlb([], [])]]))
+      const digest = computeDepsDigest([])
+      const digests = new Map([['hGlb', digest]])
+      composedGlbFilename = canonicalFilenameForAsset('hGlb', '.glb', 'windows', digests)
+
+      // Seed stale canonical bytes — force should overwrite them.
       await components.cdnS3
-        .putObject({ Bucket: 'test-bucket', Key: 'v48/assets/hGlb_windows', Body: 'cached-glb' })
+        .putObject({ Bucket: 'test-bucket', Key: `v48/assets/${composedGlbFilename}`, Body: 'stale-glb' })
         .promise()
 
       mockedGetActiveEntity.mockResolvedValue({
         id: 'bafy-force',
         type: 'scene',
-        content: [{ file: 'model.glb', hash: 'hGlb' }],
+        content,
         metadata: {}
       })
 
       mockedRunConversion.mockImplementation(async (_l: any, _c: any, options: any) => {
         await fs.mkdir(options.outDirectory, { recursive: true })
-        await fs.writeFile(path.join(options.outDirectory, 'hGlb_windows'), 'freshly-converted')
+        await fs.writeFile(path.join(options.outDirectory, composedGlbFilename), 'fresh-glb')
         return 0
       })
 
@@ -492,20 +501,16 @@ describe('when executing a conversion with asset-reuse enabled', () => {
       expect(exitCode).toBe(0)
     })
 
-    it('should invoke Unity despite the cache being warm', () => {
+    it('should invoke Unity despite the cache being warm (force bypasses short-circuit)', () => {
       expect(mockedRunConversion).toHaveBeenCalledTimes(1)
     })
 
-    it('should NOT pass a cachedHashes list to Unity', () => {
+    it('should not pass cachedHashes to Unity (force skips the cache probe)', () => {
       expect(mockedRunConversion.mock.calls[0][2].cachedHashes).toBeUndefined()
     })
 
-    it('should upload the freshly-converted bundle to the entity-scoped path (reuse path is gated off by force)', async () => {
-      expect(await read(components.cdnS3, 'test-bucket', 'v48/bafy-force/hGlb_windows')).toContain('freshly-converted')
-    })
-
-    it('should leave the pre-seeded canonical bytes untouched', async () => {
-      expect(await read(components.cdnS3, 'test-bucket', 'v48/assets/hGlb_windows')).toBe('cached-glb')
+    it('should overwrite existing canonical bytes with the freshly converted output', async () => {
+      expect(await read(components.cdnS3, 'test-bucket', `v48/assets/${composedGlbFilename}`)).toBe('fresh-glb')
     })
   })
 


### PR DESCRIPTION
## Summary

- **`force=true` now refreshes canonical bundles instead of regressing to entity-scoped uploads.** Previously `useAssetReuse` was gated by `!force`, so a forced re-conversion uploaded to `{abVersion}/{entityId}/...` and left the existing canonical objects untouched — the opposite of an operator's intent when re-queuing a scene with bad bundles.
- **Mechanism**: keep `useAssetReuse` on when forced (so canonical uploads still happen), but skip the cache probe (`checkAssetCache`). With `cacheResult=null`, `cachedHashes` stays undefined and Unity reconverts every asset, overwriting the stale canonical bytes.
- **`force` is now checked in two conceptual spots**: `shouldIgnoreConversion` bypass (existing) and the cache-probe gate (new). The `!force` guard on the full-cache short-circuit becomes redundant — when forced, `fullCacheHit` is unreachable since the probe never runs.

## Routing to entity-scoped uploads after this change

`force` is no longer one of the conditions that disables `useAssetReuse`. Entity-scoped uploads (`{abVersion}/{entityId}/...`) still happen when any of these are true:

1. `ASSET_REUSE_ENABLED=false` — the kill switch.
2. `doISS=true` — ISS conversions stay isolated so v2004 bytes don't pollute the v48 canonical prefix (or vice-versa).
3. `entityType !== 'scene'` — wearables, emotes, and other non-scene entities. The canonical reuse design only models scenes today.
4. `entity == null` — catalyst fetch failed (timeout, 404, network). Without entity content we can't compute per-glb digests, so we degrade to entity-scoped uploads against raw hashes.

## Test plan

- [x] \`yarn build\` passes
- [x] \`yarn test\` — all 335 tests pass
- [x] \`yarn lint:fix\` clean
- [x] Updated \`force=true and the canonical prefix is fully populated\` integration test to assert canonical overwrite (was: assert entity-scoped fallback + canonical untouched)
- [ ] Verify in staging: queue a scene with \`force=true\`, confirm canonical bytes change

🤖 Generated with [Claude Code](https://claude.com/claude-code)