### PR TITLE
fix: case-insensitive content-map lookup for glTF dep resolution

### DIFF
--- a/consumer-server/src/logic/asset-reuse.ts
+++ b/consumer-server/src/logic/asset-reuse.ts
@@ -690,8 +690,13 @@ export async function computePerAssetDigests(
   const aggregateTimeoutMs = options?.aggregateTimeoutMs
 
   const content = entity.content ?? []
+  // Case-insensitive lookup: glTF URIs and entity content-map paths may
+  // differ only in casing (e.g. "Floor03_Normal.png" vs "Floor03_normal.png").
+  // macOS/Windows file systems paper over this, so Unity converts fine — but a
+  // strict Map.get() would falsely mark the dep as missing. Lowercasing keys
+  // mirrors the case-insensitive resolution Unity relies on.
   const contentByFile = new Map<string, string>()
-  for (const c of content) contentByFile.set(c.file, c.hash)
+  for (const c of content) contentByFile.set(c.file.toLowerCase(), c.hash)
 
   const contentsBaseUrl = normalizeContentsBaseUrl(contentServerUrl)
 
@@ -755,7 +760,7 @@ export async function computePerAssetDigests(
             }
           }
         }
-        const hash = contentByFile.get(resolved)
+        const hash = contentByFile.get(resolved.toLowerCase())
         if (!hash) {
           return {
             kind: 'skip',

--- a/consumer-server/test/e2e/conversion.spec.ts
+++ b/consumer-server/test/e2e/conversion.spec.ts
@@ -33,6 +33,9 @@ type SceneDef = {
 }
 
 const SCENES: SceneDef[] = [
+  // Temporary: zone 0,0 has glbs with case-mismatched dep URIs (e.g. Floor03_Normal vs Floor03_normal).
+  // Confirm the case-insensitive fix works — no "Skipping glb/gltf assets" warning should appear in logs.
+  { name: 'Zone 0,0 (case-sensitivity check)', coords: '0,0', baseUrl: CATALYST_BASE_URL, isWorld: false },
   { name: 'ABTestScene1.dcl.eth', coords: '0,0', baseUrl: WORLDS_BASE_URL, isWorld: true },
   { name: 'ABTestScene2.dcl.eth', coords: '0,0', baseUrl: WORLDS_BASE_URL, isWorld: true, expectedNewFiles: 8 },
   { name: 'Catalyst 19,3', coords: '19,3', baseUrl: CATALYST_BASE_URL, isWorld: false, expectedNewFiles: 0 },

--- a/consumer-server/test/e2e/conversion.spec.ts
+++ b/consumer-server/test/e2e/conversion.spec.ts
@@ -33,9 +33,6 @@ type SceneDef = {
 }
 
 const SCENES: SceneDef[] = [
-  // Temporary: zone 0,0 has glbs with case-mismatched dep URIs (e.g. Floor03_Normal vs Floor03_normal).
-  // Confirm the case-insensitive fix works — no "Skipping glb/gltf assets" warning should appear in logs.
-  { name: 'Zone 0,0 (case-sensitivity check)', coords: '0,0', baseUrl: CATALYST_BASE_URL, isWorld: false },
   { name: 'ABTestScene1.dcl.eth', coords: '0,0', baseUrl: WORLDS_BASE_URL, isWorld: true },
   { name: 'ABTestScene2.dcl.eth', coords: '0,0', baseUrl: WORLDS_BASE_URL, isWorld: true, expectedNewFiles: 8 },
   { name: 'Catalyst 19,3', coords: '19,3', baseUrl: CATALYST_BASE_URL, isWorld: false, expectedNewFiles: 0 },

--- a/consumer-server/test/unit/asset-reuse.spec.ts
+++ b/consumer-server/test/unit/asset-reuse.spec.ts
@@ -426,6 +426,30 @@ describe('when computing per-asset digests', () => {
     })
   })
 
+  describe('and a glb references a dep whose content-map path differs only in casing', () => {
+    let result: Awaited<ReturnType<typeof computePerAssetDigests>>
+
+    beforeEach(async () => {
+      const entity = {
+        content: [
+          // Content map uses lowercase "normal", glb URI uses uppercase "Normal"
+          { file: 'models/floor.glb', hash: 'hFloor' },
+          { file: 'models/Floor03_normal.png', hash: 'hNormal' }
+        ]
+      }
+      const fetcher = makeFetcher(new Map([['hFloor', buildGlb(['Floor03_Normal.png'])]]))
+      result = await computePerAssetDigests(entity, 'https://peer.decentraland.org/content', { fetcher })
+    })
+
+    it('should resolve the dep via case-insensitive lookup and produce a digest', () => {
+      expect(result.digests.get('hFloor')).toMatch(/^[0-9a-f]{32}$/)
+    })
+
+    it('should not mark the glb as skipped', () => {
+      expect(result.skipped.size).toBe(0)
+    })
+  })
+
   describe('and the entity has only one glb and it is broken', () => {
     let result: Awaited<ReturnType<typeof computePerAssetDigests>>
 


### PR DESCRIPTION
## Summary
- glTF URIs baked into glb files can differ in casing from the entity content-map paths (e.g. `Floor03_Normal.png` vs `Floor03_normal.png`, `nekkoSign_mat_basecolor.png` vs `nekkoSign_mat_baseColor.png`)
- Unity resolves these fine via the case-insensitive macOS/Windows file system, but our `contentByFile.get()` was case-sensitive — falsely marking valid deps as `missing-deps` and skipping entire glbs from conversion
- Fix: lowercase both sides of the `contentByFile` lookup so casing mismatches no longer produce spurious skips

## Verification
A temporary e2e test was added (and then reverted) to convert the zone 0,0 scene — which previously skipped 28 glbs due to casing mismatches. CI logs confirmed **zero** `missing-deps` warnings with the fix applied. The test was reverted because zone 0,0 is too large for the e2e suite (it consumed the full timeout and cascaded failures to the other test scenes).

## Test plan
- [x] New unit test: glb references dep whose content-map path differs only in casing → digest produced, not skipped
- [x] All 103 existing asset-reuse tests pass
- [x] Verified on CI with zone 0,0 e2e conversion — no "Skipping glb/gltf assets" warning in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)