### PR TITLE
fix: world undeployed events get hanged in the ab queue

### DIFF
--- a/consumer-server/src/service.ts
+++ b/consumer-server/src/service.ts
@@ -44,6 +44,17 @@ export async function main(program: Lifecycle.EntryPointParameters<AppComponents
       }
 
       await components.taskQueue.consumeAndProcessJob(async (job, _message) => {
+        // Skip non-conversion payloads that may leak into the queue (e.g. world_undeployment).
+        if (!job?.entity?.entityId) {
+          logger.warn('Skipping job with no entity.entityId — not a conversion job', {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            type: (job as any)?.type,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            subType: (job as any)?.subType
+          })
+          return
+        }
+
         let statusCode: number
         try {
           components.metrics.increment('ab_converter_running_conversion')

--- a/consumer-server/test/integration/service-skip-non-conversion.spec.ts
+++ b/consumer-server/test/integration/service-skip-non-conversion.spec.ts
@@ -1,0 +1,162 @@
+// Regression coverage for the queue-consumer guard in service.ts: jobs that
+// arrive without `entity.entityId` (e.g. world_undeployment payloads that leak
+// into the SQS topic) must be skipped without invoking the conversion path or
+// publishing a finished event, AND must not block subsequent valid jobs.
+
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+import { createLogComponent } from '@well-known-components/logger'
+import { createMetricsComponent } from '@well-known-components/metrics'
+import { metricDeclarations } from '../../src/metrics'
+import { createMemoryQueueAdapter } from '../../src/adapters/task-queue'
+import { createRunnerComponent, IRunnerComponent } from '../../src/adapters/runner'
+import { ITaskQueue } from '../../src/adapters/task-queue'
+import { IBaseComponent } from '@well-known-components/interfaces'
+import { DeploymentToSqs } from '@dcl/schemas/dist/misc/deployments-to-sqs'
+
+jest.mock('../../src/logic/conversion-task', () => ({
+  executeConversion: jest.fn(),
+  executeLODConversion: jest.fn()
+}))
+
+jest.mock('check-disk-space', () => ({
+  __esModule: true,
+  default: jest.fn(async () => ({ free: 100 * 1e9, size: 200 * 1e9, diskPath: '/' }))
+}))
+
+import { executeConversion, executeLODConversion } from '../../src/logic/conversion-task'
+import { main } from '../../src/service'
+
+const mockedExecuteConversion = executeConversion as jest.Mock
+const mockedExecuteLODConversion = executeLODConversion as jest.Mock
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  throw new Error('Timed out waiting for queue consumer to advance')
+}
+
+describe('when the conversion worker consumes a job from the queue', () => {
+  let runner: IRunnerComponent
+  let taskQueue: ITaskQueue<DeploymentToSqs> & IBaseComponent
+  let publishMessage: jest.Mock
+
+  beforeEach(async () => {
+    mockedExecuteConversion.mockResolvedValue(0)
+    mockedExecuteLODConversion.mockResolvedValue(0)
+
+    const config = createConfigComponent({
+      PLATFORM: 'windows',
+      BUILD_TARGET: 'windows',
+      AB_VERSION_WINDOWS: 'v48',
+      AB_VERSION_MAC: 'v48',
+      AB_VERSION: ''
+    })
+    const metrics = await createMetricsComponent(metricDeclarations, { config })
+    const logs = await createLogComponent({ metrics })
+
+    publishMessage = jest.fn(async () => undefined)
+    runner = createRunnerComponent()
+    taskQueue = createMemoryQueueAdapter<DeploymentToSqs>({ logs, metrics }, { queueName: 'test-queue' })
+
+    const components = {
+      config,
+      logs,
+      server: { use: jest.fn(), setContext: jest.fn() } as any,
+      taskQueue,
+      runner,
+      metrics,
+      publisher: { publishMessage },
+      cdnS3: {} as any,
+      sentry: {} as any,
+      fetch: {} as any,
+      statusChecks: {} as any
+    }
+
+    await main({
+      components,
+      startComponents: async () => {
+        await runner.start!({ started: () => true, live: () => true, getComponents: () => ({}) } as any)
+      }
+    } as any)
+  })
+
+  afterEach(async () => {
+    // Stop runner first to flip isRunning=false; then close the queue so the
+    // pending consumeAndProcessJob resolves and the loop can exit.
+    const stopRunner = runner.stop()
+    await taskQueue.stop!()
+    await stopRunner
+    jest.clearAllMocks()
+  })
+
+  describe('and the job is a non-conversion payload missing entity.entityId (e.g. world_undeployment)', () => {
+    beforeEach(async () => {
+      // Publish the malformed job, then a valid job behind it. When the valid
+      // job has been processed we know the malformed one has been dequeued too
+      // (the in-memory queue is FIFO and serial), so we can assert what the
+      // worker did — and didn't — do for each.
+      await taskQueue.publish({ type: 'world_undeployment' } as any)
+      await taskQueue.publish({
+        entity: { entityId: 'bafy-valid-after-skip', authChain: [] as any },
+        contentServerUrls: ['https://peer.decentraland.org/content']
+      })
+      await waitFor(() => mockedExecuteConversion.mock.calls.length >= 1)
+    })
+
+    it('should call executeConversion only once — for the valid job, not the skipped one', () => {
+      expect(mockedExecuteConversion).toHaveBeenCalledTimes(1)
+    })
+
+    it('should pass the valid job entity id to executeConversion', () => {
+      expect(mockedExecuteConversion).toHaveBeenCalledWith(
+        expect.anything(),
+        'bafy-valid-after-skip',
+        'https://peer.decentraland.org/content',
+        undefined,
+        undefined,
+        undefined,
+        'v48'
+      )
+    })
+
+    it('should not invoke the LOD conversion path for the skipped job', () => {
+      expect(mockedExecuteLODConversion).not.toHaveBeenCalled()
+    })
+
+    it('should publish exactly one finished event — for the valid job, not the skipped one', () => {
+      expect(publishMessage).toHaveBeenCalledTimes(1)
+      expect(publishMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ entityId: 'bafy-valid-after-skip' })
+        })
+      )
+    })
+  })
+
+  describe('and the job has an entity but the entityId is an empty string', () => {
+    beforeEach(async () => {
+      await taskQueue.publish({ entity: { entityId: '', authChain: [] as any } } as any)
+      await taskQueue.publish({
+        entity: { entityId: 'bafy-valid-after-empty', authChain: [] as any },
+        contentServerUrls: ['https://peer.decentraland.org/content']
+      })
+      await waitFor(() => mockedExecuteConversion.mock.calls.length >= 1)
+    })
+
+    it('should treat the empty entityId as not-a-conversion-job and skip it', () => {
+      expect(mockedExecuteConversion).toHaveBeenCalledTimes(1)
+      expect(mockedExecuteConversion).toHaveBeenCalledWith(
+        expect.anything(),
+        'bafy-valid-after-empty',
+        expect.any(String),
+        undefined,
+        undefined,
+        undefined,
+        'v48'
+      )
+    })
+  })
+})


### PR DESCRIPTION
This PR only processes events that have an entityId.