### PR TITLE
fix: release in-flight SQS message on SIGTERM/SIGINT

### DIFF
--- a/consumer-server/src/adapters/task-queue.ts
+++ b/consumer-server/src/adapters/task-queue.ts
@@ -17,6 +17,9 @@ export interface ITaskQueue<T> {
   consumeAndProcessJob<R>(
     taskRunner: (job: T, message: TaskQueueMessage) => Promise<R>
   ): Promise<{ result: R | undefined }>
+  // Returns the in-flight message (if any) to the queue immediately, so another worker can pick
+  // it up without waiting for the visibility timeout to expire. Intended for graceful shutdown.
+  releaseInFlight(): Promise<void>
 }
 
 export const queueMetrics = validateMetricsDeclaration({
@@ -34,6 +37,11 @@ export const queueMetrics = validateMetricsDeclaration({
   job_queue_failures_total: {
     type: IMetricsComponent.CounterType,
     help: 'Total amount of failed tasks',
+    labelNames: ['queue_name']
+  },
+  job_queue_releases_total: {
+    type: IMetricsComponent.CounterType,
+    help: 'Total amount of in-flight messages released back to the queue (e.g. on SIGTERM)',
     labelNames: ['queue_name']
   }
 })
@@ -64,6 +72,9 @@ export function createMemoryQueueAdapter<T>(
       components.metrics.increment('job_queue_enqueue_total', { queue_name: options.queueName })
       return message
     },
+    async releaseInFlight() {
+      // in-memory queue has no separate "in-flight" state to release
+    },
     async consumeAndProcessJob(taskRunner) {
       const it: InternalElement = (await q.next()).value
       if (it) {
@@ -93,6 +104,12 @@ export function createSqsAdapter<T>(
   const logger = components.logs.getLogger(options.queueUrl)
 
   const sqs = new SQS({ apiVersion: 'latest', region: options.queueRegion })
+
+  // Tracks the message currently being processed. Set right after a message is claimed
+  // and cleared right before we delete or release it, so releaseInFlight() knows what
+  // to NACK on shutdown without racing the success path.
+  let inFlight: { receiptHandle: string; queueUrl: string; messageId: string } | undefined
+  let released = false
 
   async function receiveMessage(
     quantityOfMessages: number
@@ -157,6 +174,25 @@ export function createSqsAdapter<T>(
       components.metrics.increment('job_queue_enqueue_total', { queue_name: options.queueUrl })
       return m
     },
+    async releaseInFlight() {
+      const current = inFlight
+      if (!current || released) return
+      released = true
+      inFlight = undefined
+      logger.info(`Releasing in-flight message back to queue`, { id: current.messageId })
+      try {
+        await sqs
+          .changeMessageVisibility({
+            QueueUrl: current.queueUrl,
+            ReceiptHandle: current.receiptHandle,
+            VisibilityTimeout: 0
+          })
+          .promise()
+        components.metrics.increment('job_queue_releases_total', { queue_name: current.queueUrl })
+      } catch (err: any) {
+        logger.error(err)
+      }
+    },
     async consumeAndProcessJob(taskRunner) {
       while (true) {
         try {
@@ -165,6 +201,8 @@ export function createSqsAdapter<T>(
           if (!!response && response.Messages && response.Messages.length > 0) {
             for (const it of response.Messages) {
               const message: TaskQueueMessage = { id: it.MessageId! }
+              inFlight = { receiptHandle: it.ReceiptHandle!, queueUrl: queueUsed, messageId: message.id }
+              released = false
               const { end } = components.metrics.startTimer('job_queue_duration_seconds', {
                 queue_name: options.queueUrl
               })
@@ -181,7 +219,13 @@ export function createSqsAdapter<T>(
 
                 return { result: undefined, message }
               } finally {
-                await sqs.deleteMessage({ QueueUrl: queueUsed, ReceiptHandle: it.ReceiptHandle! }).promise()
+                // If releaseInFlight() already returned this message to the queue, skip the delete
+                // so we don't ack a job we've just NACKed.
+                const stillOurs = inFlight?.receiptHandle === it.ReceiptHandle
+                inFlight = undefined
+                if (stillOurs) {
+                  await sqs.deleteMessage({ QueueUrl: queueUsed, ReceiptHandle: it.ReceiptHandle! }).promise()
+                }
                 end()
               }
             }

--- a/consumer-server/src/service.ts
+++ b/consumer-server/src/service.ts
@@ -27,6 +27,26 @@ export async function main(program: Lifecycle.EntryPointParameters<AppComponents
 
   const logger = components.logs.getLogger('main-loop')
 
+  // On graceful shutdown, return any in-flight queue message to the queue immediately so another
+  // worker can pick it up. Without this, the message stays invisible for the SQS visibility
+  // timeout (~3h) and the conversion is effectively lost until then.
+  // Lifecycle's built-in handler catches SIGTERM and stops components in parallel; SIGINT is not
+  // handled by Lifecycle, so we cover it here too. process.once avoids duplicate releases if the
+  // signal somehow re-fires.
+  const releaseOnShutdown = async (signal: NodeJS.Signals) => {
+    logger.info(`Received ${signal}, releasing in-flight job before shutdown`)
+    try {
+      await Promise.race([
+        components.taskQueue.releaseInFlight(),
+        new Promise<void>((_, reject) => setTimeout(() => reject(new Error('release timed out')), 5000))
+      ])
+    } catch (err: any) {
+      logger.error(err)
+    }
+  }
+  process.once('SIGTERM', () => void releaseOnShutdown('SIGTERM'))
+  process.once('SIGINT', () => void releaseOnShutdown('SIGINT'))
+
   components.runner.runTask(async (opt) => {
     const platform = (await components.config.requireString('PLATFORM')).toLocaleLowerCase() as
       | 'windows'

--- a/consumer-server/test/unit/task-queue.spec.ts
+++ b/consumer-server/test/unit/task-queue.spec.ts
@@ -1,0 +1,172 @@
+import { createSqsAdapter } from '../../src/adapters/task-queue'
+
+jest.mock('aws-sdk', () => {
+  const sqsMock = {
+    receiveMessage: jest.fn(),
+    deleteMessage: jest.fn(),
+    changeMessageVisibility: jest.fn(),
+    sendMessage: jest.fn()
+  }
+  return {
+    SQS: jest.fn().mockImplementation(() => sqsMock),
+    __sqsMock: sqsMock
+  }
+})
+
+const sqsMock = (require('aws-sdk') as any).__sqsMock as {
+  receiveMessage: jest.Mock
+  deleteMessage: jest.Mock
+  changeMessageVisibility: jest.Mock
+  sendMessage: jest.Mock
+}
+
+function makeComponents() {
+  return {
+    logs: {
+      getLogger: () => ({
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+        log: jest.fn()
+      })
+    },
+    metrics: {
+      increment: jest.fn(),
+      decrement: jest.fn(),
+      observe: jest.fn(),
+      startTimer: jest.fn().mockReturnValue({ end: jest.fn() }),
+      reset: jest.fn(),
+      resetAll: jest.fn(),
+      getValue: jest.fn(),
+      register: jest.fn()
+    }
+  } as any
+}
+
+function mockOneMessage(receiptHandle = 'rh-1', messageId = 'msg-1') {
+  sqsMock.receiveMessage.mockReturnValueOnce({
+    promise: () =>
+      Promise.resolve({
+        Messages: [
+          {
+            MessageId: messageId,
+            ReceiptHandle: receiptHandle,
+            Body: JSON.stringify({ Message: JSON.stringify({ entity: { entityId: 'e1' } }) })
+          }
+        ]
+      })
+  })
+}
+
+describe('createSqsAdapter releaseInFlight', () => {
+  beforeEach(() => {
+    sqsMock.receiveMessage.mockReset()
+    sqsMock.deleteMessage.mockReset()
+    sqsMock.changeMessageVisibility.mockReset()
+    sqsMock.sendMessage.mockReset()
+    sqsMock.deleteMessage.mockReturnValue({ promise: () => Promise.resolve({}) })
+    sqsMock.changeMessageVisibility.mockReturnValue({ promise: () => Promise.resolve({}) })
+  })
+
+  it('releases in-flight message via changeMessageVisibility(0) and skips delete', async () => {
+    mockOneMessage('rh-1', 'msg-1')
+    const adapter = createSqsAdapter<any>(makeComponents(), { queueUrl: 'q-url' })
+
+    let resolveStarted!: () => void
+    const started = new Promise<void>((r) => (resolveStarted = r))
+    let resolveTask!: (v: number) => void
+    const taskPromise = new Promise<number>((r) => (resolveTask = r))
+
+    const consume = adapter.consumeAndProcessJob(async () => {
+      resolveStarted()
+      return taskPromise
+    })
+
+    await started
+    await adapter.releaseInFlight()
+
+    expect(sqsMock.changeMessageVisibility).toHaveBeenCalledTimes(1)
+    expect(sqsMock.changeMessageVisibility).toHaveBeenCalledWith({
+      QueueUrl: 'q-url',
+      ReceiptHandle: 'rh-1',
+      VisibilityTimeout: 0
+    })
+
+    resolveTask(0)
+    await consume
+
+    expect(sqsMock.deleteMessage).not.toHaveBeenCalled()
+  })
+
+  it('successful task path deletes the message and never releases', async () => {
+    mockOneMessage('rh-2', 'msg-2')
+    const adapter = createSqsAdapter<any>(makeComponents(), { queueUrl: 'q-url' })
+
+    await adapter.consumeAndProcessJob(async () => 0)
+
+    expect(sqsMock.deleteMessage).toHaveBeenCalledTimes(1)
+    expect(sqsMock.deleteMessage).toHaveBeenCalledWith({ QueueUrl: 'q-url', ReceiptHandle: 'rh-2' })
+    expect(sqsMock.changeMessageVisibility).not.toHaveBeenCalled()
+
+    // No in-flight after success — releaseInFlight is a no-op.
+    await adapter.releaseInFlight()
+    expect(sqsMock.changeMessageVisibility).not.toHaveBeenCalled()
+  })
+
+  it('releaseInFlight is a no-op when nothing is in flight', async () => {
+    const adapter = createSqsAdapter<any>(makeComponents(), { queueUrl: 'q-url' })
+
+    await adapter.releaseInFlight()
+
+    expect(sqsMock.changeMessageVisibility).not.toHaveBeenCalled()
+    expect(sqsMock.deleteMessage).not.toHaveBeenCalled()
+  })
+
+  it('only releases once when called multiple times for the same message', async () => {
+    mockOneMessage('rh-3', 'msg-3')
+    const adapter = createSqsAdapter<any>(makeComponents(), { queueUrl: 'q-url' })
+
+    let resolveStarted!: () => void
+    const started = new Promise<void>((r) => (resolveStarted = r))
+    let resolveTask!: (v: number) => void
+    const taskPromise = new Promise<number>((r) => (resolveTask = r))
+
+    const consume = adapter.consumeAndProcessJob(async () => {
+      resolveStarted()
+      return taskPromise
+    })
+
+    await started
+    await Promise.all([adapter.releaseInFlight(), adapter.releaseInFlight(), adapter.releaseInFlight()])
+
+    expect(sqsMock.changeMessageVisibility).toHaveBeenCalledTimes(1)
+
+    resolveTask(0)
+    await consume
+  })
+
+  it('release survives a changeMessageVisibility error without throwing', async () => {
+    mockOneMessage('rh-4', 'msg-4')
+    sqsMock.changeMessageVisibility.mockReturnValueOnce({
+      promise: () => Promise.reject(new Error('aws boom'))
+    })
+    const adapter = createSqsAdapter<any>(makeComponents(), { queueUrl: 'q-url' })
+
+    let resolveStarted!: () => void
+    const started = new Promise<void>((r) => (resolveStarted = r))
+    let resolveTask!: (v: number) => void
+    const taskPromise = new Promise<number>((r) => (resolveTask = r))
+
+    const consume = adapter.consumeAndProcessJob(async () => {
+      resolveStarted()
+      return taskPromise
+    })
+
+    await started
+    await expect(adapter.releaseInFlight()).resolves.toBeUndefined()
+
+    resolveTask(0)
+    await consume
+  })
+})


### PR DESCRIPTION
## Summary
- When a worker received `SIGTERM` mid-conversion (e.g. rolling deploy, autoscale-down), the SQS message stayed invisible for the full **3h visibility timeout** (`task-queue.ts:112,129`) before another worker could pick it up — the conversion was effectively lost for hours even with idle capacity available.
- The consumer-server had no signal handlers and `consumeAndProcessJob`'s `finally`-based delete never ran when the process was killed, so neither delete nor NACK happened.
- This PR adds `releaseInFlight()` on the task queue: it tracks the in-flight message and, on shutdown, calls `ChangeMessageVisibility(VisibilityTimeout: 0)` to return it to the queue immediately. `SIGTERM` and `SIGINT` handlers in `service.ts` invoke it (with a 5s timeout). Hard kills (SIGKILL/OOM) still fall back to the visibility timeout — unchanged.

## Changes
- `consumer-server/src/adapters/task-queue.ts` — interface gains `releaseInFlight()`. SQS adapter tracks `inFlight` via closure; `releaseInFlight()` calls `changeMessageVisibility(0)`. The `finally` skips `deleteMessage` if the message was already released so we don't ack a NACKed job. Memory adapter has a no-op. New `job_queue_releases_total` metric for observability.
- `consumer-server/src/service.ts` — `process.once('SIGTERM' | 'SIGINT')` handlers race the release against a 5s timeout. `SIGTERM` is also caught by Lifecycle's built-in handler (which stops components in parallel) — the two don't conflict.
- `consumer-server/test/unit/task-queue.spec.ts` — 5 new tests for the SQS adapter: release path skips delete, success path deletes, no-op when nothing in-flight, idempotent on repeated calls, tolerates AWS errors.

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` passes
- [x] `npx eslint src/adapters/task-queue.ts src/service.ts` passes
- [x] `npx jest --forceExit` — 7/7 tests pass (5 new + 2 existing)
- [ ] Manual: send `SIGTERM` to a staging worker mid-conversion; confirm `job_queue_releases_total` increments and the message is picked up by another worker within seconds (not hours)
- [ ] Manual: confirm successful conversions still delete normally (no spurious release on the success path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)