### PR TITLE
fix: retry truncated GLB fetches in per-asset digest pass

### DIFF
--- a/consumer-server/src/logic/asset-reuse.ts
+++ b/consumer-server/src/logic/asset-reuse.ts
@@ -543,7 +543,13 @@ async function readGlbJsonPrefix(url: string, res: FetchResponse): Promise<Buffe
     reader.releaseLock()
   }
 
-  throw new NonRetryableFetchError(
+  // A stream that ends before the JSON chunk is complete is a transport-level
+  // truncation (catalyst/CDN dropped the connection mid-body), not a content
+  // defect: the underlying glb at this hash is unchanged. Throwing
+  // `RetryableFetchError` lets `withFetchRetries` re-issue the request — a
+  // single CDN burp no longer collapses the digest pass and pins the entity
+  // under a permanent `_failed.json` sentinel in `executeConversion`.
+  throw new RetryableFetchError(
     targetBytes === undefined
       ? `glb/gltf at ${url} ended before the 20-byte GLB JSON header was available`
       : `glb/gltf at ${url} ended after ${total} bytes, before JSON chunk end ${targetBytes}`

--- a/consumer-server/src/logic/asset-reuse.ts
+++ b/consumer-server/src/logic/asset-reuse.ts
@@ -457,9 +457,25 @@ async function fetchFullWithContentLengthGuard(url: string, res: FetchResponse):
 
 /**
  * Stream a full response body into memory with a hard upper bound.
+ *
+ * When the response declares a `Content-Length`, we treat a stream that ends
+ * with fewer bytes than declared as a transport-level truncation and throw
+ * `RetryableFetchError` so `withFetchRetries` re-issues the request. Symmetric
+ * with the truncation check in `readGlbJsonPrefix` for `.glb` — a catalyst/CDN
+ * connection drop mid-body isn't a content defect, the bytes at this hash are
+ * unchanged. Chunked responses without a declared length can't be checked
+ * this way (we have no expected total to compare against), so we accept
+ * whatever drained; the burden then falls on the downstream parser to detect
+ * structural defects from the partial bytes.
+ *
+ * `assertDeclaredLengthWithinGuard` has already enforced the upper bound on
+ * the declared length, so any value reaching this check is in `[0, MAX]`.
  */
 async function readWholeStream(url: string, res: FetchResponse): Promise<Buffer> {
   if (!res.body) throw new RetryableFetchError(`glb/gltf at ${url} returned no response body stream`)
+
+  const declaredLength = contentLength(res)
+  const expectedTotal = Number.isFinite(declaredLength) && declaredLength >= 0 ? declaredLength : undefined
 
   const reader = res.body.getReader()
   const chunks: Buffer[] = []
@@ -485,6 +501,12 @@ async function readWholeStream(url: string, res: FetchResponse): Promise<Buffer>
     throw err
   } finally {
     reader.releaseLock()
+  }
+
+  if (expectedTotal !== undefined && total < expectedTotal) {
+    throw new RetryableFetchError(
+      `glb/gltf at ${url} ended after ${total} bytes, before declared Content-Length ${expectedTotal}`
+    )
   }
 
   return Buffer.concat(chunks, total)

--- a/consumer-server/test/unit/asset-reuse.spec.ts
+++ b/consumer-server/test/unit/asset-reuse.spec.ts
@@ -667,43 +667,45 @@ describe('when computing per-asset digests with the default gltf fetcher', () =>
     })
   })
 
-  describe('and a stream ends before the GLB JSON header is complete', () => {
-    let thrown: unknown
+  describe('and a stream ends before the GLB JSON header is complete but a retry returns the full glb', () => {
+    let digests: ReadonlyMap<string, string>
 
     beforeEach(async () => {
       const glb = buildGlb(['texture.png'])
-      mockedFetch.mockResolvedValue(responseForChunks([glb.subarray(0, 10)]))
-      try {
-        await computePerAssetDigests(entityWithGlb(), 'https://peer.decentraland.org/content')
-      } catch (err: unknown) {
-        thrown = err
-      }
+      mockedFetch
+        .mockResolvedValueOnce(responseForChunks([glb.subarray(0, 10)]))
+        .mockResolvedValueOnce(responseForChunks([glb]))
+
+      digests = (await computePerAssetDigests(entityWithGlb(), 'https://peer.decentraland.org/content')).digests
     })
 
-    it('should reject without retrying', () => {
-      expect(thrown).toBeInstanceOf(Error)
-      expect((thrown as Error).message).toMatch(/ended before the 20-byte GLB JSON header/)
-      expect(mockedFetch).toHaveBeenCalledTimes(1)
+    it('should retry the request', () => {
+      expect(mockedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should compute the digest from the retried response', () => {
+      expect(digests.get('hGlb')).toMatch(/^[0-9a-f]{32}$/)
     })
   })
 
-  describe('and a stream ends before the declared GLB JSON chunk is complete', () => {
-    let thrown: unknown
+  describe('and a stream ends before the declared GLB JSON chunk is complete but a retry returns the full glb', () => {
+    let digests: ReadonlyMap<string, string>
 
     beforeEach(async () => {
       const glb = buildGlb(['texture.png'])
-      mockedFetch.mockResolvedValue(responseForChunks([glb.subarray(0, 24)]))
-      try {
-        await computePerAssetDigests(entityWithGlb(), 'https://peer.decentraland.org/content')
-      } catch (err: unknown) {
-        thrown = err
-      }
+      mockedFetch
+        .mockResolvedValueOnce(responseForChunks([glb.subarray(0, 24)]))
+        .mockResolvedValueOnce(responseForChunks([glb]))
+
+      digests = (await computePerAssetDigests(entityWithGlb(), 'https://peer.decentraland.org/content')).digests
     })
 
-    it('should reject without retrying', () => {
-      expect(thrown).toBeInstanceOf(Error)
-      expect((thrown as Error).message).toMatch(/before JSON chunk end/)
-      expect(mockedFetch).toHaveBeenCalledTimes(1)
+    it('should retry the request', () => {
+      expect(mockedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should compute the digest from the retried response', () => {
+      expect(digests.get('hGlb')).toMatch(/^[0-9a-f]{32}$/)
     })
   })
 

--- a/consumer-server/test/unit/asset-reuse.spec.ts
+++ b/consumer-server/test/unit/asset-reuse.spec.ts
@@ -709,6 +709,29 @@ describe('when computing per-asset digests with the default gltf fetcher', () =>
     })
   })
 
+  describe('and every attempt returns a truncated GLB stream', () => {
+    let thrown: unknown
+
+    beforeEach(async () => {
+      const glb = buildGlb(['texture.png'])
+      mockedFetch.mockResolvedValue(responseForChunks([glb.subarray(0, 10)]))
+      try {
+        await computePerAssetDigests(entityWithGlb(), 'https://peer.decentraland.org/content')
+      } catch (err: unknown) {
+        thrown = err
+      }
+    })
+
+    it('should attempt the request GLTF_FETCH_ATTEMPTS times before giving up', () => {
+      expect(mockedFetch).toHaveBeenCalledTimes(3)
+    })
+
+    it('should propagate the truncation error to the caller', () => {
+      expect(thrown).toBeInstanceOf(Error)
+      expect((thrown as Error).message).toMatch(/ended before the 20-byte GLB JSON header/)
+    })
+  })
+
   describe('and a stream errors before the GLB JSON chunk is complete but a retry succeeds', () => {
     let digests: ReadonlyMap<string, string>
     let cancel: jest.Mock
@@ -937,6 +960,101 @@ describe('when computing per-asset digests with the default gltf fetcher', () =>
 
     it('should stream the full JSON document and compute the digest', () => {
       expect(digests.get('hGltf')).toMatch(/^[0-9a-f]{32}$/)
+    })
+  })
+
+  describe('and a text gltf stream ends before the declared Content-Length but a retry returns the full body', () => {
+    let digests: ReadonlyMap<string, string>
+
+    beforeEach(async () => {
+      const gltf = Buffer.from(JSON.stringify({ images: [{ uri: 'texture.png' }] }), 'utf8')
+      const entity = {
+        content: [
+          { file: 'model.gltf', hash: 'hGltf' },
+          { file: 'texture.png', hash: 'hTexture' }
+        ]
+      }
+      // First response: streams only half the body but declares the full
+      // Content-Length — the catalyst said "100 bytes", the wire delivered 50.
+      mockedFetch
+        .mockResolvedValueOnce(
+          responseForChunks([gltf.subarray(0, Math.floor(gltf.length / 2))], { contentLength: gltf.length })
+        )
+        .mockResolvedValueOnce(responseForChunks([gltf]))
+
+      digests = (await computePerAssetDigests(entity, 'https://peer.decentraland.org/content')).digests
+    })
+
+    it('should retry the request', () => {
+      expect(mockedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should compute the digest from the retried response', () => {
+      expect(digests.get('hGltf')).toMatch(/^[0-9a-f]{32}$/)
+    })
+  })
+
+  describe('and every attempt returns a truncated text gltf stream', () => {
+    let thrown: unknown
+
+    beforeEach(async () => {
+      const gltf = Buffer.from(JSON.stringify({ images: [{ uri: 'texture.png' }] }), 'utf8')
+      const entity = {
+        content: [
+          { file: 'model.gltf', hash: 'hGltf' },
+          { file: 'texture.png', hash: 'hTexture' }
+        ]
+      }
+      mockedFetch.mockResolvedValue(
+        responseForChunks([gltf.subarray(0, Math.floor(gltf.length / 2))], { contentLength: gltf.length })
+      )
+      try {
+        await computePerAssetDigests(entity, 'https://peer.decentraland.org/content')
+      } catch (err: unknown) {
+        thrown = err
+      }
+    })
+
+    it('should attempt the request GLTF_FETCH_ATTEMPTS times before giving up', () => {
+      expect(mockedFetch).toHaveBeenCalledTimes(3)
+    })
+
+    it('should propagate the truncation error to the caller', () => {
+      expect(thrown).toBeInstanceOf(Error)
+      expect((thrown as Error).message).toMatch(/before declared Content-Length/)
+    })
+  })
+
+  describe('and a text gltf is delivered chunked without a Content-Length header', () => {
+    // Chunked transfer encoding has no declared total — we can't tell short-
+    // read from valid-end at the fetcher layer. We accept whatever drained;
+    // any structural defect in the partial bytes surfaces as `unparseable`
+    // from the downstream parser rather than as a retry.
+    let result: Awaited<ReturnType<typeof computePerAssetDigests>>
+
+    beforeEach(async () => {
+      const gltf = Buffer.from(JSON.stringify({ images: [{ uri: 'texture.png' }] }), 'utf8')
+      const entity = {
+        content: [
+          { file: 'model.gltf', hash: 'hGltf' },
+          { file: 'texture.png', hash: 'hTexture' }
+        ]
+      }
+      // Send the full body but with no Content-Length signal — the fetcher
+      // accepts and returns it; the downstream parser sees a valid JSON.
+      mockedFetch.mockResolvedValue(
+        responseForChunks([gltf], { contentLength: Number.NaN as unknown as number })
+      )
+
+      result = await computePerAssetDigests(entity, 'https://peer.decentraland.org/content')
+    })
+
+    it('should not retry when no Content-Length is declared', () => {
+      expect(mockedFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should compute the digest from whatever the stream delivered', () => {
+      expect(result.digests.get('hGltf')).toMatch(/^[0-9a-f]{32}$/)
     })
   })
 })


### PR DESCRIPTION
## Summary

- Reclassify the two "GLB stream ended before the JSON chunk was complete" errors in `readGlbJsonPrefix` from `NonRetryableFetchError` to `RetryableFetchError`, so `withFetchRetries` retries them.
- Rewrite the two unit tests that locked in the old "no retry" behavior to prove retry + recovery.

## Why

While the per-asset digest pass downloads each scene glb from the catalyst, a transient connection drop mid-body (catalyst/CDN truncates the response after status 200 but before the GLB JSON chunk is fully delivered) was throwing `NonRetryableFetchError`. Two consequences:

1. `withFetchRetries` never retried the same request (`isRetryableFetchError` returns `false` for `NonRetryableFetchError`).
2. The thrown error bubbled to `executeConversion`'s digest-phase catch (`conversion-task.ts:441`), which writes `manifest/{entityId}_failed.json` with a 1h cache and returns exit code 5. That sentinel pins the scene as permanently failed: subsequent SQS retries short-circuit on it, and the scene only recovers once an operator deletes the manifest by hand.

So a single CDN burp during one of the dozens of glb fetches in a scene would permanently take that scene out of the conversion pipeline — even though the bytes at the content hash are unchanged and the next fetch would succeed.

Concrete example caught in production today: scene `bafkreibvuyboe724agvjhh2pp2xe7mytqz2t5wvaw6g6fisle4yhhuyp54` ("Decentraland Art Week 2024 - Roads") got a `_failed.json` sentinel on `.today` with error `glb/gltf at <…>/teleportersLvl1.glb ended before the 20-byte GLB JSON header was available`. The underlying glb at that hash fetches cleanly on retry — verified by re-fetching the same URL 5× from a fresh client, all 5 returning the full 557904-byte body.

## How

`consumer-server/src/logic/asset-reuse.ts:546` — change the post-loop throw at the bottom of `readGlbJsonPrefix` from `NonRetryableFetchError` to `RetryableFetchError`. The error covers both short-read cases (stream ended before the 20-byte GLB header, and stream ended after some bytes but before the declared JSON chunk end). A short comment documents *why* this is retryable — transport-level truncation isn't a content defect.

After the change, `withFetchRetries` makes up to `GLTF_FETCH_ATTEMPTS = 3` attempts with exponential backoff (`250ms × 2^attempt + jitter`, bounded ≤ 30s by `Retry-After` if the catalyst supplies one). Only after the third attempt also short-reads does the error escape to `executeConversion` and trigger the `_failed.json` sentinel.

Other `NonRetryableFetchError` callsites in the same file (size-cap violations, missing Content-Length when there's no stream body, etc.) are content/configuration defects, not transport flakes, and stay non-retryable.

`consumer-server/test/unit/asset-reuse.spec.ts` — the two tests that baked in the old behavior (`'and a stream ends before the GLB JSON header is complete' → 'should reject without retrying'` and the analogous chunk-end variant) are rewritten to:

1. Mock the fetch to return the short stream on attempt 1, full glb on attempt 2.
2. Assert the fetch was called twice (retry happened) and the digest is computed from the recovered response.

Pattern mirrors the existing `and a stream errors before the GLB JSON chunk is complete but a retry succeeds` test (lines 710-742) so the suite reads consistently. Real-time backoff is ~250ms × 1 retry — same order of magnitude as the existing retry test.

## Out of scope

- **Reclassifying the analogous `.gltf` text path.** `readWholeStream` returns whatever bytes arrived; a truncated text glTF would fail later inside `parseGltfDepRefs` and become an `unparseable` skip, not a hard failure that writes `_failed.json`. Worth revisiting separately — `unparseable` is content-deterministic by contract, but a truncated stream isn't content-deterministic — out of scope here.
- **The stale sentinels already on the CDN.** This PR only prevents new sentinels from being written by transient truncations; pre-existing `_failed.json` files (including the Art Week scene above) still need to be removed via `delete-canonical-assets --mode manifests` for those scenes to convert.

## Test plan

- [x] `yarn jest test/unit/asset-reuse.spec.ts` — 105/105 pass (was 105/105 before; two existing tests now assert retry+recovery instead of no-retry)
- [x] `yarn jest` — full suite 348/348 pass
- [x] `yarn build` — clean
- [x] `yarn lint:check` — clean