### PR TITLE
chore: harden e2e CI against UPM git-fetch flakiness and missing AWS region

### DIFF
--- a/asset-bundle-converter/Packages/manifest.json
+++ b/asset-bundle-converter/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.atteneder.draco": "4.0.2",
     "com.atteneder.ktx": "2.2.3",
-    "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
+    "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask#305695ad5d194dda0d6b00777c2459202a1ef4ea",
     "com.unity.assetbundlebrowser": "https://github.com/Unity-Technologies/AssetBundles-Browser.git",
     "com.unity.ide.rider": "3.0.38",
     "com.unity.ide.visualstudio": "2.0.23",

--- a/asset-bundle-converter/Packages/packages-lock.json
+++ b/asset-bundle-converter/Packages/packages-lock.json
@@ -19,7 +19,7 @@
       "url": "https://package.openupm.com"
     },
     "com.cysharp.unitask": {
-      "version": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
+      "version": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask#305695ad5d194dda0d6b00777c2459202a1ef4ea",
       "depth": 0,
       "source": "git",
       "dependencies": {},

--- a/consumer-server/test/e2e/conversion.spec.ts
+++ b/consumer-server/test/e2e/conversion.spec.ts
@@ -48,6 +48,12 @@ process.env.PLATFORM = $BUILD_TARGET
 process.env.ASSET_REUSE_ENABLED = 'true'
 // AWS_SNS_ARN is required by the publisher component at init time
 process.env.AWS_SNS_ARN = process.env.AWS_SNS_ARN || 'arn:aws:sns:us-east-1:000000000000:e2e-test'
+// AWS_REGION is required by the SNS v3 client to sign the publish call. Without
+// it, every post-conversion publish fails with "Region is missing" before any
+// network attempt — noisy in CI logs and obscures a real SNS regression. The
+// fake ARN above means the request never reaches a real SNS endpoint anyway,
+// so any region that lets the SDK construct the signed request will do.
+process.env.AWS_REGION = process.env.AWS_REGION || 'us-east-1'
 
 const MOCK_S3_BASE = '/tmp/e2e-mock-s3'
 const BUCKET_NAME = 'CDN_BUCKET' // default when CDN_BUCKET env is unset


### PR DESCRIPTION
## Summary

- Pin `com.cysharp.unitask` to its current commit in `Packages/manifest.json` so UPM stops re-resolving HEAD against `github.com` on every Unity boot inside the converter Docker image.
- Default `AWS_REGION` to `us-east-1` in `test/e2e/conversion.spec.ts` so the SNS v3 client can sign post-conversion publishes instead of throwing `Region is missing`.

Both issues were surfaced concretely by run 25671595635 on PR #283 — the dedup phase of the e2e step failed because GitHub returned HTTP 500 for `https://github.com/Cysharp/UniTask.git`, and the same run also logged `[ERROR] (ConversionTaskQueue): Error: Region is missing` after every successful conversion.

## Why

### 1. UPM git-fetch dependency

`asset-bundle-converter/Packages/manifest.json` referenced UniTask as an unpinned Git URL:

```
"com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask"
```

UPM follows this URL to resolve HEAD whenever its package cache isn't warm — which is every fresh Unity boot in the converter's CI Docker image, because `Library/PackageCache` isn't preserved between e2e Unity invocations. When `github.com` returns a 5xx (intermittent, but real — happened today on run 25671595635), the package resolution fails. Unity exits 1 during `Application.AssetDatabase Initial Refresh Start`, the e2e test sees `/tmp/asset_bundles_contents/entity_<id>` empty, and the dedup phase fails the entire job. No retry on the Unity side, no graceful degradation; the only signal is `fatal: unable to access 'https://github.com/Cysharp/UniTask.git/': The requested URL returned error: 500` buried in Unity's stdout.

### 2. SNS region

`consumer-server/src/adapters/sns.ts` instantiates `new SNSClient({ endpoint: optionalEndpoint })` with no explicit region — the v3 SDK picks it up from `AWS_REGION`. The e2e test config already sets a fake `AWS_SNS_ARN` (`arn:aws:sns:us-east-1:000000000000:e2e-test`) at `conversion.spec.ts:50`, but never sets `AWS_REGION`. Every successful conversion in the e2e run therefore logs:

```
[ERROR] (ConversionTaskQueue): Error: Region is missing
    at Object.publishMessage (/consumer-server/src/adapters/sns.ts:35:5)
```

This is benign today (the error is caught and the test continues) but it's noise in every CI run and would mask a real SNS regression if one landed.

## How

### Manifest pin

Append `#<commit-sha>` to the UniTask URL in both `Packages/manifest.json` and the matching `Packages/packages-lock.json` entry (so the two files stay consistent — UPM cross-checks them).

The SHA chosen is **`305695ad5d194dda0d6b00777c2459202a1ef4ea`** — the exact value already recorded in `packages-lock.json` (`"hash": "305695ad…"`). That means:

- **No version upgrade.** This is the same UniTask commit the project has been building against for months — a 2023-04-25 revert commit that sits between tagged releases. I deliberately did **not** pin to `2.5.10` (which is commit `7c0f199…`, a different tree). Pinning to a tag would have been a multi-month version bump and out of scope for an infra-hardening change.
- **UPM can cache by SHA.** With an explicit ref, UPM treats the package as immutable for that ref and serves it from `Library/PackageCache` without revalidating against the remote.
- **Reproducible builds.** Two Docker rebuilds from this commit always pull the same UniTask bytes.

Other unpinned Git deps in this manifest (`io.sentry.unity`, `com.unity.assetbundlebrowser`, `net.tnrd.nsubstitute`) have the same flakiness shape but didn't fail in this incident — left for a follow-up so this change stays surgical.

### AWS_REGION default

Add `process.env.AWS_REGION = process.env.AWS_REGION || 'us-east-1'` next to the existing `AWS_SNS_ARN` default at `test/e2e/conversion.spec.ts:50`. The chosen region matches the region encoded in the fake ARN (`arn:aws:sns:us-east-1:…`), so the two values stay aligned for any operator reading the test. The fake ARN means the publish never reaches a real SNS endpoint regardless of region — the env var just lets the SDK construct a signed request and fail cleanly downstream (likely on missing credentials), which is caught by the existing error path.

## Out of scope / follow-ups

- **Other unpinned Git deps**: `io.sentry.unity`, `com.unity.assetbundlebrowser`, `net.tnrd.nsubstitute`. Same hardening pattern would apply; not bundled here so this PR stays minimal and the diff is easy to revert if UPM behaves unexpectedly with the SHA pin.
- **Warming `Library/PackageCache` at Docker build time**: an alternative/complementary fix that would let unpinned Git URLs still work between boots inside one image. More invasive (Dockerfile change), so left as a separate option if pinning alone proves insufficient.
- **Stopping the SNS publish from running at all in e2e**: cleaner long-term — the test doesn't care about the publish — but requires a code change in `service.ts` or a mock publisher. Region default is the surgical fix; the architectural cleanup is its own PR.

## Test plan

- [x] `yarn build` — clean
- [x] `yarn lint:check` — clean
- [x] `yarn jest` — full suite still 356/356 (no JS code changed)
- [ ] CI: webgl/mac/windows e2e steps pass without `Region is missing` log lines, and Unity boots without re-fetching UniTask from GitHub.