### PR TITLE
fix: cachebust on retry to bypass poisoned CDN cache entries

### DIFF
--- a/consumer-server/src/logic/asset-reuse.ts
+++ b/consumer-server/src/logic/asset-reuse.ts
@@ -583,12 +583,16 @@ async function readGlbJsonPrefix(url: string, res: FetchResponse): Promise<Buffe
  * carries a parsed `Retry-After` hint (populated by `assertOkResponse` on
  * 408/429/503 responses), the hint wins over our exponential-backoff formula
  * — a cooperating catalyst knows better than we do how long to back off.
+ *
+ * The callback receives the zero-based `attempt` number so it can vary its
+ * request between tries — `defaultGltfFetcher` uses this to add a cachebust
+ * query param on retries that bypasses CDN caches.
  */
-async function withFetchRetries<T>(fn: () => Promise<T>): Promise<T> {
+async function withFetchRetries<T>(fn: (attempt: number) => Promise<T>): Promise<T> {
   let lastError: unknown
   for (let attempt = 0; attempt < GLTF_FETCH_ATTEMPTS; attempt++) {
     try {
-      return await fn()
+      return await fn(attempt)
     } catch (err: unknown) {
       lastError = err
       if (attempt === GLTF_FETCH_ATTEMPTS - 1 || !isRetryableFetchError(err)) throw err
@@ -600,6 +604,20 @@ async function withFetchRetries<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 /**
+ * Append a `_retry={attempt}` query parameter to a fetch URL so it bypasses
+ * any intermediate CDN cache (Cloudflare, CloudFront) by changing the cache
+ * key. Catalyst content endpoints are keyed only by the CID in the path and
+ * ignore unknown query parameters, so this is a transparent transform on the
+ * server side; from the CDN's point of view it's a fresh URL that triggers a
+ * MISS and a pull from origin.
+ */
+function withRetryQueryParam(url: string, attempt: number): string {
+  const u = new URL(url)
+  u.searchParams.set('_retry', String(attempt))
+  return u.toString()
+}
+
+/**
  * Default fetcher — wraps native fetch with a non-ok status check, retries,
  * a Content-Length guard, and streaming reads. Binary GLBs are only streamed
  * through the embedded JSON chunk; text GLTFs are fully streamed because the
@@ -607,11 +625,26 @@ async function withFetchRetries<T>(fn: () => Promise<T>): Promise<T> {
  *
  * Uses `arrayBuffer()` only as a guarded fallback for mocked / non-standard
  * responses that do not expose a stream body.
+ *
+ * Retries past attempt 0 add `?_retry={attempt}` to force a CDN MISS. A
+ * one-off transient short-read on attempt 0 is recoverable by hitting the
+ * same cache entry again, but a *deterministic* short-read is most often a
+ * poisoned CDN cache fill that will replay the broken body to every request
+ * landing on the same edge POP. Without the cachebust the retry just re-reads
+ * the same corrupted cached bytes and gives up after exhausting attempts;
+ * with it, the second attempt forces a fresh origin pull, the cache refills
+ * with a clean body, and subsequent workers benefit too (broken object
+ * effectively gets evicted).
  */
 async function defaultGltfFetcher(url: string, ext: '.glb' | '.gltf'): Promise<Buffer> {
-  return withFetchRetries(async () => {
+  return withFetchRetries(async (attempt) => {
+    const fetchUrl = attempt === 0 ? url : withRetryQueryParam(url, attempt)
     const init = ext === '.glb' ? { headers: { 'Accept-Encoding': 'identity' } } : undefined
-    const res = (await fetch(url, init)) as FetchResponse
+    const res = (await fetch(fetchUrl, init)) as FetchResponse
+    // Error messages from the readers carry the URL — pass the original
+    // (without `?_retry=N`) so production logs and sentry triage stay
+    // grep-able by content hash and aren't fragmented by retry-attempt
+    // variants of the same logical URL.
     return ext === '.glb' ? readGlbJsonPrefix(url, res) : fetchFullWithContentLengthGuard(url, res)
   })
 }

--- a/consumer-server/test/integration/execute-conversion.spec.ts
+++ b/consumer-server/test/integration/execute-conversion.spec.ts
@@ -76,11 +76,28 @@ function buildComponents(bucketBasePath: string, params: Params = {}) {
 
 // Wire up native fetch so glb/gltf digest reads return declared fixtures and
 // scene source files return a tiny body.
+//
+// URL matching is path-based, not suffix-based, so retries that carry a
+// cachebust query param (`?_retry=N`, added by `defaultGltfFetcher` on retry
+// to bypass poisoned CDN caches) still match their content hash. Naïve
+// `asString.endsWith(hash)` matching would let retry URLs fall through and
+// quietly succeed against the source-file fallback, masking failures the
+// test is trying to verify.
+function urlPathLastSegment(url: string): string | undefined {
+  try {
+    return new URL(url).pathname.split('/').pop()
+  } catch {
+    return undefined
+  }
+}
+
 function setupFetchMock(glbsByHash: Map<string, Buffer>): void {
   const implementation = async (url: any) => {
     const asString = typeof url === 'string' ? url : url?.toString() ?? ''
-    for (const [hash, buf] of glbsByHash) {
-      if (asString.endsWith(hash)) return responseFor(buf)
+    const lastSegment = urlPathLastSegment(asString)
+    if (lastSegment) {
+      const buf = glbsByHash.get(lastSegment)
+      if (buf) return responseFor(buf)
     }
     return responseFor(Buffer.from('fake-source-file'))
   }
@@ -856,7 +873,7 @@ describe('when executing a conversion with asset-reuse enabled', () => {
       // entity still flows through to Unity-produced output.
       const implementation = async (url: any) => {
         const asString = typeof url === 'string' ? url : url?.toString() ?? ''
-        if (asString.endsWith('hBadGlb')) {
+        if (urlPathLastSegment(asString) === 'hBadGlb') {
           return responseFor(Buffer.from('not-a-glb-at-all'))
         }
         return responseFor(Buffer.from('fake-source-file'))
@@ -946,7 +963,7 @@ describe('when executing a conversion with asset-reuse enabled', () => {
       // Sentry visibility because it might indicate catalyst trouble.
       const implementation = async (url: any) => {
         const asString = typeof url === 'string' ? url : url?.toString() ?? ''
-        if (asString.endsWith('hBrokenFetch')) {
+        if (urlPathLastSegment(asString) === 'hBrokenFetch') {
           return {
             ok: false,
             status: 500,
@@ -1426,7 +1443,7 @@ describe('when executing a conversion with asset-reuse enabled', () => {
       // to 404 so uploadSceneSourceFilesToCDN hits the error branch.
       mockedFetch.mockImplementation(async (url: any) => {
         const asString = typeof url === 'string' ? url : url?.toString() ?? ''
-        if (asString.endsWith('hGlb')) {
+        if (urlPathLastSegment(asString) === 'hGlb') {
           return responseFor(buildGlb([], []))
         }
         // Source file fetches → 404

--- a/consumer-server/test/unit/asset-reuse.spec.ts
+++ b/consumer-server/test/unit/asset-reuse.spec.ts
@@ -732,6 +732,39 @@ describe('when computing per-asset digests with the default gltf fetcher', () =>
     })
   })
 
+  describe('and a retry is triggered by a transient failure', () => {
+    let urls: string[]
+
+    beforeEach(async () => {
+      const glb = buildGlb(['texture.png'])
+      // Two short reads followed by a full glb on the third attempt — exercises
+      // attempts 0, 1, and 2 so we can assert the URL transform on each one.
+      mockedFetch
+        .mockResolvedValueOnce(responseForChunks([glb.subarray(0, 10)]))
+        .mockResolvedValueOnce(responseForChunks([glb.subarray(0, 10)]))
+        .mockResolvedValueOnce(responseForChunks([glb]))
+
+      await computePerAssetDigests(entityWithGlb(), 'https://peer.decentraland.org/content')
+      urls = mockedFetch.mock.calls.map((c) => String(c[0]))
+    })
+
+    it('should use the unmodified URL on the first attempt so a healthy CDN cache is leveraged', () => {
+      expect(urls[0]).toBe('https://peer.decentraland.org/content/contents/hGlb')
+    })
+
+    it('should append _retry=1 on the second attempt to bypass a poisoned CDN cache entry', () => {
+      const u = new URL(urls[1])
+      expect(u.origin + u.pathname).toBe('https://peer.decentraland.org/content/contents/hGlb')
+      expect(u.searchParams.get('_retry')).toBe('1')
+    })
+
+    it('should append _retry=2 on the third attempt', () => {
+      const u = new URL(urls[2])
+      expect(u.origin + u.pathname).toBe('https://peer.decentraland.org/content/contents/hGlb')
+      expect(u.searchParams.get('_retry')).toBe('2')
+    })
+  })
+
   describe('and a stream errors before the GLB JSON chunk is complete but a retry succeeds', () => {
     let digests: ReadonlyMap<string, string>
     let cancel: jest.Mock


### PR DESCRIPTION
## Summary

- `defaultGltfFetcher` appends `?_retry={attempt}` to its fetch URL on every retry past attempt 0. Catalyst content endpoints key only on the CID in the path and ignore unknown query params, so it's a transparent transform server-side; from the CDN's point of view it's a fresh URL that triggers a MISS and pulls fresh bytes from origin.
- Attempt 0 still uses the unmodified URL so the healthy path keeps leveraging the CDN cache.

## Why

PR #283 made transient short-reads retryable, which is correct for the *network-blip* failure mode. But it leaves a second, harder failure unaddressed: a **deterministically poisoned CDN cache entry**.

Concrete occurrence in production today (entity `bafkreibvuyboe…` on `.today`, scene "Decentraland Art Week 2024 - Roads"):

- Cloudflare's catalyst zone (`peer.decentraland.today`) cached a *truncated* body for one of the scene's glb CIDs at the POP serving the converter (likely IAD/us-east-1).
- Every fetch from that POP returned the same broken cached object — Cloudflare's `cf-cache-status: HIT`, ~10 bytes of body, stream closed cleanly.
- The converter's retry loop hit the same poisoned cache on every attempt → 3× short-read → `_failed.json` written → scene pinned.
- Same URL from a different POP (the operator's local network) returned the full 557904 bytes consistently. `?cachebust=…` against the catalyst returned the full body from origin. So origin was healthy the whole time.
- Catalyst responses carry `cache-control: public, max-age=31536000` — the broken cache entry would have sat there serving truncated bytes to the same POP for **up to a year** without manual purge.

This failure mode is intrinsic to retrying against a content-addressed CDN: as long as all retries land on the same cached object, retrying alone cannot help. The fix is to make the retry hit a different CDN cache key. The simplest robust way is a query-string twiddle: catalyst ignores it server-side, CDN treats it as a fresh URL.

Bonus self-heal: the fresh origin pull on retry also *refills* the CDN with a clean body, so subsequent workers (and other client traffic to that POP) see the good version. The broken object effectively evicts itself.

## How

`asset-reuse.ts`:

- `withFetchRetries<T>` signature changes from `fn: () => Promise<T>` to `fn: (attempt: number) => Promise<T>`. Internal loop already had the attempt counter; just plumbs it through to the callback.
- New helper `withRetryQueryParam(url, attempt)` builds the cachebust URL via the `URL` constructor so it composes cleanly with any pre-existing query string (none today, but defence in depth).
- `defaultGltfFetcher` becomes:
  ```ts
  return withFetchRetries(async (attempt) => {
    const fetchUrl = attempt === 0 ? url : withRetryQueryParam(url, attempt)
    ...
    return ext === '.glb' ? readGlbJsonPrefix(url, res) : fetchFullWithContentLengthGuard(url, res)
  })
  ```
  Note `readGlbJsonPrefix(url, …)` keeps receiving the **original** URL — error messages and Sentry triage stay grep-able by content hash, not fragmented across `_retry=N` variants.

Why a query param rather than a custom header? Catalyst responses are cached *by URL* at the CDN; varying a header wouldn't change the cache key. Query param is the standard cache-busting transform and works at every Cloudflare/CloudFront layer without configuration.

Why `_retry=N` (numeric) rather than a random nonce? Deterministic across retries within a job (each attempt has a stable URL), so log correlation across retries is straightforward. Also makes the URL transform easy to assert on in tests.

## Tests

Unit (`test/unit/asset-reuse.spec.ts`): new describe block `'and a retry is triggered by a transient failure'` mocks two short-read responses followed by a full glb on the third attempt, then captures `mockedFetch.mock.calls` and asserts:

1. Attempt 0 uses `https://peer.decentraland.org/content/contents/hGlb` (no query param)
2. Attempt 1 uses the same origin+path with `?_retry=1`
3. Attempt 2 uses the same origin+path with `?_retry=2`

Integration (`test/integration/execute-conversion.spec.ts`): the existing fetch mocks matched URLs with `asString.endsWith(hash)`. That stopped working under retry because the retry URL ends with `?_retry=N` instead of the bare hash, falling through to the source-file fallback and quietly succeeding instead of preserving the test's intended failure path. Switched all four call sites (and the shared `setupFetchMock` helper) to path-based matching:

```ts
const lastSegment = new URL(asString).pathname.split('/').pop()
if (lastSegment === 'hBrokenFetch') { ... }
```

This is a strictly more robust match — it handles `?_retry=N` for free and would also handle future cachebust transforms without test churn.

Verified:

- [x] `yarn jest test/unit/asset-reuse.spec.ts` — 116 passed (was 113; +3 new for the URL-transform test)
- [x] `yarn jest test/integration/execute-conversion.spec.ts` — 73 passed (the four that broke under the unmodified mocks now match URLs correctly)
- [x] `yarn build` — clean
- [x] `yarn lint:check` — clean

## Out of scope

- **Purging the existing poisoned cache entry** that triggered this investigation: that's a Cloudflare-zone action on the catalyst zone, handled by the world-content-server team. This PR doesn't depend on it; with this code merged, the next conversion attempt for that scene would self-heal on retry.
- **Bumping `GLTF_FETCH_ATTEMPTS`** beyond 3: more attempts would help when *origin* is intermittently broken, but origin has been healthy in every observed instance — the failure is CDN-cache layer. Three attempts with a fresh URL on retry covers it.
- **Cachebust for the leaf bundle uploads / S3 reads** in `checkAssetCache`: those use the AWS SDK directly against S3 (not via the catalyst's Cloudflare). No CDN cache in that path to bust.