### PR TITLE
fix: detect world deployments when contentServerUrls has a single entry

### DIFF
--- a/consumer-server/src/logic/conversion-orchestrator/component.ts
+++ b/consumer-server/src/logic/conversion-orchestrator/component.ts
@@ -103,10 +103,7 @@ export async function createConversionOrchestratorComponent(
         platform: platform,
         entityId: job.entity.entityId,
         isLods: !!job.lods,
-        isWorld:
-          !!job.contentServerUrls &&
-          job.contentServerUrls.length > 1 &&
-          job.contentServerUrls[0].includes('worlds-content-server'),
+        isWorld: !!job.contentServerUrls?.length && job.contentServerUrls[0].includes('worlds-content-server'),
         statusCode,
         version: versionToUse
       }


### PR DESCRIPTION
## Summary

The `AssetBundleConversionFinished` event published by the consumer-server was setting `isWorld: false` for world deployments because the gate required **`contentServerUrls.length > 1`** — which is never the case today. `deployments-to-sqs` sends a one-element array for both genesis and world deployments. The reliable signal is the hostname of the first URL.

## Why this matters (observed in prod)

For world \`eax.dcl.eth\` on 2026-05-21:

1. Conversion of \`bafkreigjtsfkvgcuyhzhxkqt73ghsp4z5qxc5fpehvbyakuzdcy5zv4vde\` succeeded (cached, \`exitCode: 0\`), manifests uploaded, finished event published — log line at \`14:56:29.156\`: \`Published message to SNS\`.
2. The event arrived at the asset-bundle-registry **before** the corresponding deployment event (~4 s race).
3. Inside [textures-handler](https://github.com/decentraland/asset-bundle-registry/blob/main/src/logic/handlers/textures-handler.ts), the entity lookup returned \`null\`. The back-fill branch reads \`event.metadata.isWorld\` to decide where to fetch from:
   \`\`\`ts
   if (event.metadata.isWorld) {
     fetchedEntity = await worlds.getWorld(event.metadata.entityId)
   } else {
     fetchedEntity = await catalyst.getEntityById(event.metadata.entityId)
   }
   \`\`\`
4. Because we published \`isWorld: false\`, the handler asked Catalyst — which doesn't store world entities. Lookup failed, handler returned \`{ ok: false }\`, message-processor retried once and gave up:
   \`\`\`
   14:56:33.142 textures-handler  Entity not found in the database, will create it
   14:56:33.160 textures-handler  Entity not found (metadata "isWorld": false)
   14:56:33.160 catalyst-client   Error fetching entity by id
   14:56:43.201 message-processor No handler found for the message, will not retry
   \`\`\`
5. The deployment event landed shortly after and created the row at PENDING. But the texture events were already abandoned, so \`assets.windows\` and \`assets.mac\` stayed PENDING forever — even though the manifests are on the CDN.
6. Symptom for clients: the registry kept serving the previous \`v49\` entity as \`FALLBACK\` indefinitely, while worlds-content-server pointed at the new entity. Any newer-world deployment hits this trap.

## The change

\`consumer-server/src/service.ts\` — drop the \`length > 1\` clause:

\`\`\`diff
-              isWorld:
-                !!job.contentServerUrls &&
-                job.contentServerUrls.length > 1 &&
-                job.contentServerUrls[0].includes('worlds-content-server'),
+              isWorld: !!job.contentServerUrls?.length && job.contentServerUrls[0].includes('worlds-content-server'),
\`\`\`

## Risk

- Genesis-city deployments use a Catalyst URL (\`https://peer.decentraland.org\` or similar) — \`.includes('worlds-content-server')\` is false, \`isWorld\` stays false. No behavior change.
- World deployments now correctly report \`isWorld: true\`, the registry's textures-handler will route fallback lookups to \`worlds.getWorld\`, the race condition stops producing stuck PENDING rows.

## Followups (separate PRs)

1. \`POST /queue-task\` for \`bafkreigjt…v4vde\` after deploy to unstick the world that triggered this investigation. Conversion is cached (\`ALREADY_CONVERTED\`), so the event republishes immediately with the correct \`isWorld: true\` and the registry self-heals.
2. The retry policy in the registry's \`message-processor\` is too aggressive (1 attempt + 1 retry, both within ~10 s). For races like this we'd want 3-5 retries with backoff — would have caught this without code change.

## Test plan

- [x] Conversion of a known **world** entity → published event has \`isWorld: true\`. Registry processes it without falling into the Catalyst path on miss.
- [x] Conversion of a known **genesis-city** entity → published event has \`isWorld: false\`. Behavior unchanged.
- [ ] Deploy to staging, manually queue a world entity, verify the registry transitions to COMPLETE without manual intervention.