### PR TITLE
chore: remove webgl from manual deploy matrix

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -23,8 +23,6 @@ jobs:
     strategy:
       matrix:
         include:
-        - service_name: asset-bundle-converter
-          build_target: webgl
         - service_name: asset-bundle-converter-windows
           build_target: windows
         - service_name: asset-bundle-converter-mac


### PR DESCRIPTION
## Summary
- Drops the `asset-bundle-converter` (webgl) entry from the `manual-deploy.yml` matrix so manual deploys only target the Windows and Mac services.

## Test plan
- [ ] Trigger the Manual Deploy workflow and confirm only the Windows and Mac jobs run.