### PR TITLE
feat: per-stage wall-clock histograms

### DIFF
--- a/consumer-server/src/logic/conversion-task.ts
+++ b/consumer-server/src/logic/conversion-task.ts
@@ -8,7 +8,7 @@ import { AppComponents } from '../types'
 import * as fs from 'fs'
 import * as path from 'path'
 import { hasContentChange } from './has-content-changed-task'
-import { getUnityBuildTarget } from '../utils'
+import { getUnityBuildTarget, withPhaseTimer } from '../utils'
 import { AssetCacheResult, findMetadataOnlyHashes, SkippedAsset } from './asset-reuse'
 import { Manifest } from './scenes'
 
@@ -326,16 +326,22 @@ export async function executeLODConversion(
   }
 
   try {
-    const exitCode = await components.unityRunner.runLodsConversion({
-      entityId,
-      logFile,
-      outDirectory,
-      lods,
-      unityPath: $UNITY_PATH,
-      projectPath: $PROJECT_PATH,
-      timeout: 60 * 60 * 1000,
-      unityBuildTarget
-    })
+    const exitCode = await withPhaseTimer(
+      components.metrics,
+      'ab_converter_phase_unity_seconds',
+      { build_target: $BUILD_TARGET, ab_version: abVersion },
+      () =>
+        components.unityRunner.runLodsConversion({
+          entityId,
+          logFile,
+          outDirectory,
+          lods,
+          unityPath: $UNITY_PATH,
+          projectPath: $PROJECT_PATH,
+          timeout: 60 * 60 * 1000,
+          unityBuildTarget
+        })
+    )
 
     components.metrics.increment('ab_converter_exit_codes', { exit_code: (exitCode ?? -1)?.toString() })
 
@@ -348,20 +354,26 @@ export async function executeLODConversion(
       return 5 // UNEXPECTED_ERROR exit code
     }
 
-    await uploadDir(components.cdnS3, cdnBucket, outDirectory, 'LOD', {
-      concurrency: 10,
-      matches: [
-        {
-          // the rest of the elements will be uploaded as application/wasm
-          // to be compressed and cached by cloudflare
-          match: '**/*',
-          contentType: 'application/wasm',
-          immutable: true,
-          variants: [FileVariant.Brotli, FileVariant.Uncompressed],
-          skipRepeated: true
-        }
-      ]
-    })
+    await withPhaseTimer(
+      components.metrics,
+      'ab_converter_phase_upload_seconds',
+      { build_target: $BUILD_TARGET, ab_version: abVersion },
+      () =>
+        uploadDir(components.cdnS3, cdnBucket, outDirectory, 'LOD', {
+          concurrency: 10,
+          matches: [
+            {
+              // the rest of the elements will be uploaded as application/wasm
+              // to be compressed and cached by cloudflare
+              match: '**/*',
+              contentType: 'application/wasm',
+              immutable: true,
+              variants: [FileVariant.Brotli, FileVariant.Uncompressed],
+              skipRepeated: true
+            }
+          ]
+        })
+    )
 
     return exitCode ?? -1
   } catch (error: any) {
@@ -392,26 +404,33 @@ export async function executeLODConversion(
       logger.info(`!!!!!!!! Log file not deleted or uploaded ${logFile}`, defaultLoggerMetadata)
     }
 
-    // delete output files
-    try {
-      await rimraf(logFile, { maxRetries: 3 })
-    } catch (err: any) {
-      logger.error(err, defaultLoggerMetadata)
-    }
-    try {
-      await rimraf(outDirectory, { maxRetries: 3 })
-    } catch (err: any) {
-      logger.error(err, defaultLoggerMetadata)
-    }
-    // delete library folder
-    try {
-      await rimraf(`${$PROJECT_PATH}/Library`, { maxRetries: 3 })
-    } catch (err: any) {
-      logger.error(err, defaultLoggerMetadata)
-    }
+    await withPhaseTimer(
+      components.metrics,
+      'ab_converter_phase_cleanup_seconds',
+      { build_target: $BUILD_TARGET, ab_version: abVersion },
+      async () => {
+        // delete output files
+        try {
+          await rimraf(logFile, { maxRetries: 3 })
+        } catch (err: any) {
+          logger.error(err, defaultLoggerMetadata)
+        }
+        try {
+          await rimraf(outDirectory, { maxRetries: 3 })
+        } catch (err: any) {
+          logger.error(err, defaultLoggerMetadata)
+        }
+        // delete library folder
+        try {
+          await rimraf(`${$PROJECT_PATH}/Library`, { maxRetries: 3 })
+        } catch (err: any) {
+          logger.error(err, defaultLoggerMetadata)
+        }
 
-    // delete scene manifest folder
-    await deleteSceneManifestFolder($PROJECT_PATH, logger, defaultLoggerMetadata)
+        // delete scene manifest folder
+        await deleteSceneManifestFolder($PROJECT_PATH, logger, defaultLoggerMetadata)
+      }
+    )
   }
 
   logger.debug('LOD Conversion finished', defaultLoggerMetadata)
@@ -578,15 +597,21 @@ export async function executeConversion(
         cached: outcome.cacheResult.cachedHashes.length
       } as any)
       try {
-        await components.scenes.uploadFastPathResult({
-          entity: outcome.entity,
-          contentServerUrl,
-          cdnBucket,
-          manifestFile,
-          entityScopedUploadPath: `${abVersion}/${entityId}`,
-          abVersion,
-          cacheResult: outcome.cacheResult
-        })
+        await withPhaseTimer(
+          components.metrics,
+          'ab_converter_phase_upload_seconds',
+          { build_target: $BUILD_TARGET, ab_version: abVersion },
+          () =>
+            components.scenes.uploadFastPathResult({
+              entity: outcome.entity,
+              contentServerUrl,
+              cdnBucket,
+              manifestFile,
+              entityScopedUploadPath: `${abVersion}/${entityId}`,
+              abVersion,
+              cacheResult: outcome.cacheResult
+            })
+        )
       } catch (err: any) {
         // Short-circuit failed post-probe. SQS will retry; capture for
         // visibility because the main-path error handler below never runs.
@@ -676,25 +701,31 @@ export async function executeConversion(
     logger.info(`HasContentChanged for ${entityId} result was ${hasContentChanged}`)
   }
 
-  let exitCode
+  let exitCode: number | undefined
   try {
     if (hasContentChanged) {
-      exitCode = await components.unityRunner.runConversion({
-        contentServerUrl,
-        entityId,
-        entityType,
-        logFile,
-        outDirectory,
-        projectPath: $PROJECT_PATH,
-        unityPath: $UNITY_PATH,
-        timeout: 120 * 60 * 1000, // 120min temporarily doubled
-        unityBuildTarget: unityBuildTarget,
-        animation: animation,
-        doISS: doISS,
-        cachedHashes: useAssetReuse && cacheResult ? cacheResult.unitySkippableHashes : undefined,
-        skippedHashes: unityDropHashes.size > 0 ? [...unityDropHashes] : undefined,
-        depsDigestByHash
-      })
+      exitCode = await withPhaseTimer(
+        components.metrics,
+        'ab_converter_phase_unity_seconds',
+        { build_target: $BUILD_TARGET, ab_version: abVersion },
+        () =>
+          components.unityRunner.runConversion({
+            contentServerUrl,
+            entityId,
+            entityType,
+            logFile,
+            outDirectory,
+            projectPath: $PROJECT_PATH,
+            unityPath: $UNITY_PATH,
+            timeout: 120 * 60 * 1000, // 120min temporarily doubled
+            unityBuildTarget: unityBuildTarget,
+            animation: animation,
+            doISS: doISS,
+            cachedHashes: useAssetReuse && cacheResult ? cacheResult.unitySkippableHashes : undefined,
+            skippedHashes: unityDropHashes.size > 0 ? [...unityDropHashes] : undefined,
+            depsDigestByHash
+          })
+      )
     } else {
       exitCode = 0
     }
@@ -741,39 +772,51 @@ export async function executeConversion(
 
     const bundleUploadPath = useAssetReuse ? assetReuseUploadPath : entityScopedUploadPath
 
-    // first upload the content (bundles go to the canonical prefix when reuse is on)
-    await uploadDir(components.cdnS3, cdnBucket, outDirectory, bundleUploadPath, {
-      concurrency: 10,
-      matches: [
-        {
-          match: '**/*.manifest',
-          contentType: 'text/cache-manifest',
-          immutable: true,
-          variants: [FileVariant.Brotli, FileVariant.Uncompressed]
-        },
-        {
-          // the rest of the elements will be uploaded as application/wasm
-          // to be compressed and cached by cloudflare
-          match: '**/*',
-          contentType: 'application/wasm',
-          immutable: true,
-          variants: [FileVariant.Brotli, FileVariant.Uncompressed],
-          skipRepeated: true
+    await withPhaseTimer(
+      components.metrics,
+      'ab_converter_phase_upload_seconds',
+      { build_target: $BUILD_TARGET, ab_version: abVersion },
+      async () => {
+        // first upload the content (bundles go to the canonical prefix when reuse is on)
+        await uploadDir(components.cdnS3, cdnBucket, outDirectory, bundleUploadPath, {
+          concurrency: 10,
+          matches: [
+            {
+              match: '**/*.manifest',
+              contentType: 'text/cache-manifest',
+              immutable: true,
+              variants: [FileVariant.Brotli, FileVariant.Uncompressed]
+            },
+            {
+              // the rest of the elements will be uploaded as application/wasm
+              // to be compressed and cached by cloudflare
+              match: '**/*',
+              contentType: 'application/wasm',
+              immutable: true,
+              variants: [FileVariant.Brotli, FileVariant.Uncompressed],
+              skipRepeated: true
+            }
+          ]
+        })
+
+        logger.debug('Content files uploaded', defaultLoggerMetadata)
+
+        // Upload index.js and main.crdt to CDN so the desktop Explorer client
+        // can fetch them from S3 instead of the catalyst (see issue #7625).
+        // Scene source files stay entity-scoped regardless of reuse mode.
+        if (entity && exitCode === 0 && entityType === 'scene') {
+          await components.scenes.uploadSceneSourceFilesToCDN(
+            entity,
+            contentServerUrl,
+            entityScopedUploadPath,
+            cdnBucket
+          )
         }
-      ]
-    })
 
-    logger.debug('Content files uploaded', defaultLoggerMetadata)
-
-    // Upload index.js and main.crdt to CDN so the desktop Explorer client
-    // can fetch them from S3 instead of the catalyst (see issue #7625).
-    // Scene source files stay entity-scoped regardless of reuse mode.
-    if (entity && exitCode === 0 && entityType === 'scene') {
-      await components.scenes.uploadSceneSourceFilesToCDN(entity, contentServerUrl, entityScopedUploadPath, cdnBucket)
-    }
-
-    // and then replace the manifest
-    await components.scenes.uploadEntityManifest(cdnBucket, manifestFile, manifest)
+        // and then replace the manifest
+        await components.scenes.uploadEntityManifest(cdnBucket, manifestFile, manifest)
+      }
+    )
 
     if (exitCode !== 0 || manifest.files.length === 0) {
       const log = await promises.readFile(logFile, 'utf8')
@@ -850,32 +893,39 @@ export async function executeConversion(
       logger.info(`!!!!!!!! Log file not deleted or uploaded ${logFile}`, defaultLoggerMetadata)
     }
 
-    // delete output files
-    try {
-      await rimraf(logFile, { maxRetries: 3 })
-    } catch (err: any) {
-      logger.error(err, defaultLoggerMetadata)
-    }
-    try {
-      await rimraf(outDirectory, { maxRetries: 3 })
-    } catch (err: any) {
-      logger.error(err, defaultLoggerMetadata)
-    }
-    // delete library folder
-    try {
-      await rimraf(`${$PROJECT_PATH}/Library`, { maxRetries: 3 })
-    } catch (err: any) {
-      logger.error(`Error deleting library folder: ${err}`, defaultLoggerMetadata)
-    }
-    //delete _Download folder
-    try {
-      await rimraf(`${$PROJECT_PATH}/Assets/_Downloaded`, { maxRetries: 3 })
-    } catch (err: any) {
-      logger.error(err, defaultLoggerMetadata)
-    }
+    await withPhaseTimer(
+      components.metrics,
+      'ab_converter_phase_cleanup_seconds',
+      { build_target: $BUILD_TARGET, ab_version: abVersion },
+      async () => {
+        // delete output files
+        try {
+          await rimraf(logFile, { maxRetries: 3 })
+        } catch (err: any) {
+          logger.error(err, defaultLoggerMetadata)
+        }
+        try {
+          await rimraf(outDirectory, { maxRetries: 3 })
+        } catch (err: any) {
+          logger.error(err, defaultLoggerMetadata)
+        }
+        // delete library folder
+        try {
+          await rimraf(`${$PROJECT_PATH}/Library`, { maxRetries: 3 })
+        } catch (err: any) {
+          logger.error(`Error deleting library folder: ${err}`, defaultLoggerMetadata)
+        }
+        //delete _Download folder
+        try {
+          await rimraf(`${$PROJECT_PATH}/Assets/_Downloaded`, { maxRetries: 3 })
+        } catch (err: any) {
+          logger.error(err, defaultLoggerMetadata)
+        }
 
-    // delete scene manifest folder
-    await deleteSceneManifestFolder($PROJECT_PATH, logger, defaultLoggerMetadata)
+        // delete scene manifest folder
+        await deleteSceneManifestFolder($PROJECT_PATH, logger, defaultLoggerMetadata)
+      }
+    )
   }
 
   logger.debug('Conversion finished', defaultLoggerMetadata)

--- a/consumer-server/src/logic/scenes/component.ts
+++ b/consumer-server/src/logic/scenes/component.ts
@@ -1,6 +1,6 @@
 import { Entity } from '@dcl/schemas'
 import { AppComponents } from '../../types'
-import { getUnityBuildTarget, normalizeContentsBaseUrl } from '../../utils'
+import { getUnityBuildTarget, normalizeContentsBaseUrl, withPhaseTimer } from '../../utils'
 import {
   AssetCacheResult,
   PerAssetDigestResult,
@@ -68,11 +68,10 @@ function toError(e: unknown): Error {
 export async function createScenesComponent(
   components: Pick<AppComponents, 'logs' | 'config' | 'metrics' | 'cdnS3' | 'sentry' | 'catalyst'>
 ): Promise<IScenesComponent> {
-  // `metrics` isn't destructured here because this component's own methods
-  // don't emit metrics directly — but it's required in the Pick<> because the
-  // delegated impls (`checkAssetCacheImpl` and friends) read it from the
-  // captured `components` reference passed through below.
-  const { logs, config, cdnS3, sentry, catalyst } = components
+  // Destructure everything except the captured `components` itself — that
+  // reference is forwarded verbatim to the delegated impls (`checkAssetCacheImpl`
+  // and friends) so they keep their direct access to whatever fields they read.
+  const { logs, config, metrics, cdnS3, sentry, catalyst } = components
 
   // CDN_BUCKET is a process-lifetime env var — resolve it once at construction
   // so `probe()` and downstream callers don't pay a config lookup per call.
@@ -277,7 +276,12 @@ export async function createScenesComponent(
     let entity: Entity
     let entityType: string
     try {
-      const fetched = await catalyst.getActiveEntity(entityId, contentServerUrl, CATALYST_FETCH_TIMEOUT_MS)
+      const fetched = await withPhaseTimer(
+        metrics,
+        'ab_converter_phase_catalyst_fetch_seconds',
+        { build_target: buildTarget, ab_version: abVersion },
+        () => catalyst.getActiveEntity(entityId, contentServerUrl, CATALYST_FETCH_TIMEOUT_MS)
+      )
       if (!fetched) throw new Error('entity no longer active on catalyst (redeployed or evicted)')
       entity = fetched
       entityType = entity.type
@@ -294,9 +298,12 @@ export async function createScenesComponent(
     let depsDigestByHash: ReadonlyMap<string, string>
     let skippedAssets: ReadonlyMap<string, SkippedAsset>
     try {
-      const digestResult = await computePerAssetDigests(entity, contentServerUrl, {
-        aggregateTimeoutMs: PROBE_DIGEST_TIMEOUT_MS
-      })
+      const digestResult = await withPhaseTimer(
+        metrics,
+        'ab_converter_phase_digest_seconds',
+        { build_target: buildTarget, ab_version: abVersion },
+        () => computePerAssetDigests(entity, contentServerUrl, { aggregateTimeoutMs: PROBE_DIGEST_TIMEOUT_MS })
+      )
       depsDigestByHash = digestResult.digests
       skippedAssets = digestResult.skipped
     } catch (err: any) {
@@ -352,13 +359,19 @@ export async function createScenesComponent(
 
     let cacheResult: AssetCacheResult
     try {
-      cacheResult = await checkAssetCache({
-        entity,
-        abVersion,
-        buildTarget,
-        cdnBucket,
-        depsDigestByHash
-      })
+      cacheResult = await withPhaseTimer(
+        metrics,
+        'ab_converter_phase_probe_seconds',
+        { build_target: buildTarget, ab_version: abVersion },
+        () =>
+          checkAssetCache({
+            entity,
+            abVersion,
+            buildTarget,
+            cdnBucket,
+            depsDigestByHash
+          })
+      )
     } catch (e: any) {
       logger.warn(`Asset cache probe failed: ${e?.message ?? e}`)
       return {

--- a/consumer-server/src/metrics.ts
+++ b/consumer-server/src/metrics.ts
@@ -88,6 +88,46 @@ export const metricDeclarations = {
     help: 'Counter of triage jobs that ran Unity inline on the triage pod because Conversion-queue publish failed. Pair with conversion_queue_publish_errors_total to confirm fallback coverage.',
     type: IMetricsComponent.CounterType,
     labelNames: ['build_target']
+  },
+  // Per-phase wall-clock histograms. The end-to-end `job_queue_duration_seconds`
+  // only tells us a job got slower; these tell us which phase. Buckets are
+  // sized to the typical phase duration so percentiles aren't all crowded in
+  // the rightmost bucket.
+  ab_converter_phase_catalyst_fetch_seconds: {
+    help: 'Histogram of wall-clock duration for catalyst entity fetches inside a conversion job. Includes retry-after backoff.',
+    type: IMetricsComponent.HistogramType,
+    labelNames: ['build_target', 'ab_version'],
+    buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30]
+  },
+  ab_converter_phase_digest_seconds: {
+    help: 'Histogram of wall-clock duration for per-asset (glb/gltf) digest computation, including catalyst glb-bytes fetches.',
+    type: IMetricsComponent.HistogramType,
+    labelNames: ['build_target', 'ab_version'],
+    buckets: [0.1, 0.5, 1, 2, 5, 10, 30, 60]
+  },
+  ab_converter_phase_probe_seconds: {
+    help: 'Histogram of wall-clock duration for the asset cache probe (local LRU + Redis + S3 HEAD).',
+    type: IMetricsComponent.HistogramType,
+    labelNames: ['build_target', 'ab_version'],
+    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5]
+  },
+  ab_converter_phase_unity_seconds: {
+    help: 'Histogram of wall-clock duration for the Unity child process (runConversion / runLodsConversion).',
+    type: IMetricsComponent.HistogramType,
+    labelNames: ['build_target', 'ab_version'],
+    buckets: [1, 5, 10, 30, 60, 120, 300, 600, 1200, 3600]
+  },
+  ab_converter_phase_upload_seconds: {
+    help: 'Histogram of wall-clock duration for uploadDir + manifest publishes to the CDN bucket.',
+    type: IMetricsComponent.HistogramType,
+    labelNames: ['build_target', 'ab_version'],
+    buckets: [0.5, 1, 2, 5, 10, 30, 60, 120]
+  },
+  ab_converter_phase_cleanup_seconds: {
+    help: 'Histogram of wall-clock duration for the post-conversion rimraf block (Library, outDir, _Downloaded, log file, scene manifest).',
+    type: IMetricsComponent.HistogramType,
+    labelNames: ['build_target', 'ab_version'],
+    buckets: [0.1, 0.5, 1, 2, 5, 10, 30, 60]
   }
 }
 

--- a/consumer-server/src/utils.ts
+++ b/consumer-server/src/utils.ts
@@ -48,3 +48,32 @@ export function getAbVersionEnvName(buildTarget: string) {
       throw 'Invalid buildTarget'
   }
 }
+
+/**
+ * Wrap an async `fn` with a histogram observation. Uses the WKC metrics
+ * `startTimer(name, labels)` → `{ end }` pattern; `end()` records elapsed
+ * seconds into the named histogram. Called from `try { … } finally { end() }`
+ * so a phase that throws is still measured — slow-then-fail looks the same
+ * as slow-success on the dashboard, which is what you want for capacity
+ * planning.
+ *
+ * @typeParam T - Resolved value of `fn`.
+ * @param metrics - The metrics component (any subset of `IMetricsComponent`
+ *   that exposes `startTimer`).
+ * @param name - Histogram name as declared in `metricDeclarations`.
+ * @param labels - Label values matching the histogram's `labelNames`.
+ * @param fn - The async work whose duration is recorded.
+ */
+export async function withPhaseTimer<T>(
+  metrics: { startTimer: (name: any, labels?: any) => { end: () => void } },
+  name: string,
+  labels: Record<string, string>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const { end } = metrics.startTimer(name, labels)
+  try {
+    return await fn()
+  } finally {
+    end()
+  }
+}

--- a/consumer-server/test/integration/execute-conversion.spec.ts
+++ b/consumer-server/test/integration/execute-conversion.spec.ts
@@ -233,6 +233,146 @@ describe('when executing a conversion with asset-reuse enabled', () => {
     })
   })
 
+  describe('and per-stage phase timing is observed', () => {
+    let startTimerSpy: jest.SpyInstance
+
+    beforeEach(async () => {
+      startTimerSpy = jest.spyOn(components.metrics, 'startTimer')
+
+      // Minimal entity: one already-canonical asset so the conversion takes the
+      // full-cache short-circuit. Unity isn't spawned; we still pass through
+      // catalyst fetch + digest + probe + upload + cleanup.
+      const content = [
+        { file: 'model.glb', hash: 'hGlb' },
+        { file: 'texture.png', hash: 'hTex' },
+        { file: 'main.crdt', hash: 'hMainCrdt' },
+        { file: 'scene.json', hash: 'hSceneJson' },
+        { file: 'index.js', hash: 'hIndexJs' }
+      ]
+      setupFetchMock(new Map([['hGlb', buildGlb(['texture.png'])]]))
+      const glbDigest = computeDepsDigest([{ file: 'texture.png', hash: 'hTex' }])
+      const digests = new Map([['hGlb', glbDigest]])
+      const glbFilename = canonicalFilenameForAsset('hGlb', '.glb', 'windows', digests)
+      const texFilename = canonicalFilenameForAsset('hTex', '.png', 'windows', digests)
+      await components.cdnS3
+        .putObject({ Bucket: 'test-bucket', Key: `v48/assets/${glbFilename}`, Body: 'glb-bytes' })
+        .promise()
+      await components.cdnS3
+        .putObject({ Bucket: 'test-bucket', Key: `v48/assets/${texFilename}`, Body: 'tex-bytes' })
+        .promise()
+      mockedGetActiveEntity.mockResolvedValue({
+        id: 'bafy-entity-1',
+        type: 'scene',
+        content,
+        metadata: { main: 'index.js' }
+      })
+
+      await executeConversion(
+        components,
+        'bafy-entity-1',
+        'https://peer.decentraland.org/content',
+        false,
+        undefined,
+        undefined,
+        'v48'
+      )
+    })
+
+    it('should observe the catalyst fetch phase with build_target and ab_version labels', () => {
+      expect(startTimerSpy).toHaveBeenCalledWith('ab_converter_phase_catalyst_fetch_seconds', {
+        build_target: 'windows',
+        ab_version: 'v48'
+      })
+    })
+
+    it('should observe the digest phase with build_target and ab_version labels', () => {
+      expect(startTimerSpy).toHaveBeenCalledWith('ab_converter_phase_digest_seconds', {
+        build_target: 'windows',
+        ab_version: 'v48'
+      })
+    })
+
+    it('should observe the probe phase with build_target and ab_version labels', () => {
+      expect(startTimerSpy).toHaveBeenCalledWith('ab_converter_phase_probe_seconds', {
+        build_target: 'windows',
+        ab_version: 'v48'
+      })
+    })
+
+    it('should observe the upload phase with build_target and ab_version labels (fast-path uploads count too)', () => {
+      expect(startTimerSpy).toHaveBeenCalledWith('ab_converter_phase_upload_seconds', {
+        build_target: 'windows',
+        ab_version: 'v48'
+      })
+    })
+
+    it('should NOT observe the unity phase on the full-cache short-circuit', () => {
+      expect(startTimerSpy).not.toHaveBeenCalledWith('ab_converter_phase_unity_seconds', expect.anything())
+    })
+
+    it('should NOT observe the cleanup phase on the full-cache short-circuit (nothing to clean up)', () => {
+      expect(startTimerSpy).not.toHaveBeenCalledWith('ab_converter_phase_cleanup_seconds', expect.anything())
+    })
+  })
+
+  describe('and per-stage phase timing is observed on the Unity (partial-hit) path', () => {
+    let startTimerSpy: jest.SpyInstance
+
+    beforeEach(async () => {
+      startTimerSpy = jest.spyOn(components.metrics, 'startTimer')
+
+      // Partial-hit setup: one cached glb + one un-cached texture, so the probe
+      // returns missingHashes != 0 and the Unity path runs (covers unity +
+      // upload + cleanup phases).
+      const content = [
+        { file: 'model.glb', hash: 'hGlbU' },
+        { file: 'texture.png', hash: 'hTexU' },
+        { file: 'main.crdt', hash: 'hMain' },
+        { file: 'scene.json', hash: 'hScene' },
+        { file: 'index.js', hash: 'hIndex' }
+      ]
+      setupFetchMock(new Map([['hGlbU', buildGlb(['texture.png'])]]))
+      // No canonical objects seeded — both hashes miss; Unity runs.
+      mockedGetActiveEntity.mockResolvedValue({
+        id: 'bafy-partial',
+        type: 'scene',
+        content,
+        metadata: { main: 'index.js' }
+      })
+      mockedRunConversion.mockImplementation(async (options: any) => {
+        // Touch the out-directory so the post-conversion readdir + upload have
+        // something to walk. Mirrors what the real Unity child would produce.
+        await fs.mkdir(options.outDirectory, { recursive: true })
+        await fs.writeFile(path.join(options.outDirectory, 'placeholder.manifest'), 'x')
+        return 0
+      })
+
+      await executeConversion(
+        components,
+        'bafy-partial',
+        'https://peer.decentraland.org/content',
+        false,
+        undefined,
+        undefined,
+        'v48'
+      )
+    })
+
+    it('should observe the unity phase', () => {
+      expect(startTimerSpy).toHaveBeenCalledWith('ab_converter_phase_unity_seconds', {
+        build_target: 'windows',
+        ab_version: 'v48'
+      })
+    })
+
+    it('should observe the cleanup phase', () => {
+      expect(startTimerSpy).toHaveBeenCalledWith('ab_converter_phase_cleanup_seconds', {
+        build_target: 'windows',
+        ab_version: 'v48'
+      })
+    })
+  })
+
   describe('and the entity uses the text .gltf + .bin form', () => {
     it('should fold the deps digest into the gltf canonical path and ignore the buffer in the manifest (no standalone bin bundle exists)', async () => {
       // `.gltf` (text) references `.bin` buffers by URI. The bin contributes


### PR DESCRIPTION
## Summary
- Adds six histograms (`ab_converter_phase_{catalyst_fetch,digest,probe,unity,upload,cleanup}_seconds`) labelled by `build_target` and `ab_version`. Today the only timing signal is `job_queue_duration_seconds` end-to-end — when it gets slower we have no way to localise the regression.
- All wrapping goes through a single `withPhaseTimer` helper in `utils.ts`, sitting in `try { … } finally { end() }` so phases that throw are still measured.
- The fast-path `uploadFastPathResult` is also instrumented under the upload histogram so full-cache short-circuits don't disappear from upload dashboards.

## Test plan
- [ ] `yarn test` passes (8 new integration tests assert each histogram is emitted on both full-hit and partial-hit paths)
- [ ] After a conversion in staging, `curl localhost:5001/metrics | grep ab_converter_phase_` returns populated buckets

🤖 Generated with [Claude Code](https://claude.com/claude-code)