### PR TITLE
fix: per-asset retry on S3 HEAD with miss-on-exhausted fallback

### DIFF
--- a/consumer-server/src/logic/asset-reuse.ts
+++ b/consumer-server/src/logic/asset-reuse.ts
@@ -321,6 +321,116 @@ async function headExists(s3: AppComponents['cdnS3'], bucket: string, key: strin
 }
 
 /**
+ * Number of HEAD attempts per asset before giving up. Three is enough to
+ * absorb the common transient cases (one 503, one socket reset, one
+ * throttle) without compounding scene latency past acceptable bounds: at
+ * three attempts the worst-case wait is ~100 + ~200 = ~300ms of backoff
+ * plus three round-trips.
+ */
+const HEAD_RETRY_ATTEMPTS = 3
+
+/**
+ * Base backoff in ms. Equal-jitter is applied so concurrent probes (50 in
+ * flight, by default) don't all retry on the same tick. Keep this small —
+ * the absolute floor on probe latency is set by the slowest retried probe,
+ * and a single hot asset across the fleet shouldn't add wall-clock to every
+ * scene.
+ */
+const HEAD_RETRY_BASE_DELAY_MS = 100
+
+/** Sleep that doesn't pin the event loop; equal-jitter applied at call site. */
+function delayMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Wrap `headExists` with bounded-retry semantics. Transient S3 errors (5xx,
+ * throttling, transient network) are retried with equal-jitter exponential
+ * backoff; 404s are returned as `false` immediately (the "not cached" signal
+ * is content-deterministic, not transient). On exhausted retries this
+ * function does NOT throw — it returns `false` so a per-asset HEAD failure
+ * is treated as a miss without dragging the entire probe down. The caller
+ * sees missing canonical bundles, Unity rebuilds them, and we don't lose
+ * the whole conversion to a single hot key.
+ *
+ * Emits `ab_converter_s3_head_errors_total{retry_outcome=retried|exhausted}`
+ * so dashboards can surface S3 flakiness before it spreads into Unity
+ * fallback cost.
+ *
+ * @returns `true` if the object exists, `false` on 404 OR after exhausting
+ *   retries (caller's view of "treat as miss" is identical for both — the
+ *   metric distinguishes them).
+ */
+async function headExistsWithRetry(
+  s3: AppComponents['cdnS3'],
+  bucket: string,
+  key: string,
+  metrics: AppComponents['metrics'],
+  labels: { build_target: string; ab_version: string }
+): Promise<boolean> {
+  for (let attempt = 1; attempt <= HEAD_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await headExists(s3, bucket, key)
+    } catch (err: unknown) {
+      // 404 is normalized inside headExists; reaching here means a non-404
+      // failure. Retry the transient kinds and exit early on permanent ones.
+      if (!isRetryableS3Error(err)) {
+        break
+      }
+      if (attempt < HEAD_RETRY_ATTEMPTS) {
+        metrics.increment('ab_converter_s3_head_errors_total', { ...labels, retry_outcome: 'retried' })
+        // Equal jitter: sleep in [base/2, base) × 2^(attempt-1). Spreads the
+        // 50-concurrent probe wakeup tick so we don't dogpile S3 right after a
+        // shared throttle window expires.
+        const exp = HEAD_RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1)
+        const jittered = Math.floor(exp / 2 + Math.random() * (exp / 2))
+        await delayMs(jittered)
+      }
+    }
+  }
+  // Exhausted (or hit a non-retryable error like auth). Count once and treat
+  // as a miss — Unity will rebuild whichever canonical bundle we couldn't
+  // confirm.
+  metrics.increment('ab_converter_s3_head_errors_total', { ...labels, retry_outcome: 'exhausted' })
+  return false
+}
+
+/**
+ * Distinguishes retryable S3 / network errors from permanent ones. 5xx
+ * responses, throttling, and known transient network codes get retried; auth
+ * failures, invalid-argument errors, and other 4xx (other than 404 which is
+ * already normalised upstream) do not. Conservative: when unsure, we DON'T
+ * retry — repeating an auth-failure burns the attempt budget without help,
+ * and pushing the error past the exhausted path produces the same caller
+ * outcome (treat as miss) anyway.
+ */
+function isRetryableS3Error(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { statusCode?: number; code?: string; retryable?: boolean }
+  // The AWS SDK v2 sets a `retryable` flag on its own errors. Trust it when
+  // present — the SDK already classifies its own transient cases.
+  if (e.retryable === true) return true
+  if (typeof e.statusCode === 'number' && e.statusCode >= 500 && e.statusCode < 600) return true
+  // Common transient network / throttling shapes the SDK propagates.
+  if (
+    e.code === 'ECONNRESET' ||
+    e.code === 'ETIMEDOUT' ||
+    e.code === 'EAI_AGAIN' ||
+    e.code === 'NetworkingError' ||
+    e.code === 'TimeoutError' ||
+    e.code === 'RequestTimeout' ||
+    e.code === 'ThrottlingException' ||
+    e.code === 'Throttling' ||
+    e.code === 'SlowDown' ||
+    e.code === 'ServiceUnavailable' ||
+    e.code === 'InternalError'
+  ) {
+    return true
+  }
+  return false
+}
+
+/**
  * Array-map with bounded concurrency — runs `fn` over every element of `items`
  * in parallel with at most `concurrency` in-flight promises at a time. Results
  * come back in the same order as `items`.
@@ -1099,8 +1209,18 @@ export async function checkAssetCache(
 
   const hitCacheServed = probes.length - pendingIdx.length
   if (pendingIdx.length > 0) {
+    // Per-asset retry + miss-on-exhausted lives inside `headExistsWithRetry`;
+    // a single hot key throwing 503 doesn't drag the whole probe through the
+    // Promise.all-reject path anymore. Treat exhausted retries as "miss" so
+    // Unity rebuilds whichever bundle we couldn't confirm — the canonical
+    // object either exists (next probe will re-confirm) or it doesn't
+    // (Unity uploads it). Either way the worst case is a redo, not a lost
+    // job.
     const fetched = await mapBounded(pendingIdx, concurrency, (i) =>
-      headExists(components.cdnS3, cdnBucket, probes[i].key)
+      headExistsWithRetry(components.cdnS3, cdnBucket, probes[i].key, components.metrics, {
+        build_target: buildTarget,
+        ab_version: abVersion
+      })
     )
     for (let j = 0; j < pendingIdx.length; j++) {
       hits[pendingIdx[j]] = fetched[j]

--- a/consumer-server/src/metrics.ts
+++ b/consumer-server/src/metrics.ts
@@ -64,6 +64,11 @@ export const metricDeclarations = {
     type: IMetricsComponent.CounterType,
     labelNames: ['build_target', 'ab_version']
   },
+  ab_converter_s3_head_errors_total: {
+    help: 'Counter of S3 HEAD failures inside the asset probe, labelled by retry_outcome ∈ {retried, exhausted}. `retried` means a transient error that was recovered within the attempt budget; `exhausted` means all retries failed and the probe treated the asset as a miss. A sustained spike on `retried` flags S3 flakiness before it tips into `exhausted` and Unity-fallback cost.',
+    type: IMetricsComponent.CounterType,
+    labelNames: ['build_target', 'ab_version', 'retry_outcome']
+  },
   ab_converter_glb_skipped_total: {
     help: 'Counter of glb/gltf assets silently skipped (missing dependencies or unparseable bytes)',
     type: IMetricsComponent.CounterType,

--- a/consumer-server/test/integration/execute-conversion.spec.ts
+++ b/consumer-server/test/integration/execute-conversion.spec.ts
@@ -868,8 +868,13 @@ describe('when executing a conversion with asset-reuse enabled', () => {
       expect(mockedRunConversion).toHaveBeenCalledTimes(1)
     })
 
-    it('should pass no cached hashes to Unity (cacheResult was set to null)', () => {
-      expect(mockedRunConversion.mock.calls[0][0].cachedHashes).toBeUndefined()
+    it('should pass no cached hashes to Unity (per-asset HEAD failures treated as misses)', () => {
+      // With per-asset retry-then-miss, a transient 5xx no longer throws out of
+      // the probe — the probe completes and reports every failed key as a miss.
+      // Unity therefore receives an empty cachedHashes list (which the runner
+      // filters out at spawn time, equivalent to `undefined`).
+      const cachedHashes = mockedRunConversion.mock.calls[0][0].cachedHashes
+      expect(cachedHashes === undefined || cachedHashes.length === 0).toBe(true)
     })
 
     it('should still upload to the canonical prefix at the composite glb path', async () => {

--- a/consumer-server/test/unit/asset-reuse.spec.ts
+++ b/consumer-server/test/unit/asset-reuse.spec.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises'
 import * as path from 'path'
 import * as os from 'os'
 import {
+  AssetCacheResult,
   canonicalFilenameForAsset,
   checkAssetCache,
   computeDepsDigest,
@@ -1336,29 +1337,157 @@ describe('when checking the asset cache against S3', () => {
     })
   })
 
-  describe('and S3 returns a non-404 error', () => {
-    it('should propagate the error to the caller', async () => {
-      const s3Error: any = new Error('boom')
-      s3Error.statusCode = 500
+  describe('and S3 returns a transient 5xx that recovers within the retry budget', () => {
+    let metricsCalls: Array<{ name: string; labels: any; value?: number }>
+    let result: AssetCacheResult
+    let headCallCount: number
+
+    beforeEach(async () => {
+      headCallCount = 0
       const s3: any = {
-        headObject: () => ({ promise: async () => { throw s3Error } })
+        headObject: () => ({
+          promise: async () => {
+            headCallCount++
+            if (headCallCount === 1) {
+              const err: any = new Error('throttled')
+              err.statusCode = 503
+              throw err
+            }
+            return {}
+          }
+        })
       }
       const { logger } = makeMockLogger()
+      metricsCalls = []
       const components = {
         cdnS3: s3,
         logs: { getLogger: () => logger },
-        metrics: { increment: () => {}, decrement: () => {}, observe: () => {} }
+        metrics: {
+          increment: (name: string, labels: any, value?: number) => metricsCalls.push({ name, labels, value }),
+          decrement: () => {},
+          observe: () => {}
+        }
       } as any
+      result = await checkAssetCache(components, {
+        entity: { content: [{ file: 'a.glb', hash: 'h' }] } as any,
+        abVersion: 'v48',
+        buildTarget: 'windows',
+        cdnBucket: 'bucket',
+        depsDigestByHash: new Map([['h', computeDepsDigest([])]])
+      })
+    })
 
-      await expect(
-        checkAssetCache(components, {
-          entity: { content: [{ file: 'a.glb', hash: 'h' }] } as any,
-          abVersion: 'v48',
-          buildTarget: 'windows',
-          cdnBucket: 'bucket',
-          depsDigestByHash: new Map([['h', computeDepsDigest([])]])
+    it('should report the asset as cached (retry recovered the HEAD)', () => {
+      expect(result.cachedHashes).toEqual(['h'])
+    })
+
+    it('should emit a retried counter (not exhausted)', () => {
+      const retried = metricsCalls.find(
+        (m) => m.name === 'ab_converter_s3_head_errors_total' && m.labels.retry_outcome === 'retried'
+      )
+      const exhausted = metricsCalls.find(
+        (m) => m.name === 'ab_converter_s3_head_errors_total' && m.labels.retry_outcome === 'exhausted'
+      )
+      expect(retried).toBeDefined()
+      expect(exhausted).toBeUndefined()
+    })
+  })
+
+  describe('and S3 keeps returning 5xx until the retry budget is exhausted', () => {
+    let metricsCalls: Array<{ name: string; labels: any; value?: number }>
+    let result: AssetCacheResult
+
+    beforeEach(async () => {
+      const s3: any = {
+        headObject: () => ({
+          promise: async () => {
+            const err: any = new Error('still throttled')
+            err.statusCode = 503
+            throw err
+          }
         })
-      ).rejects.toThrow('boom')
+      }
+      const { logger } = makeMockLogger()
+      metricsCalls = []
+      const components = {
+        cdnS3: s3,
+        logs: { getLogger: () => logger },
+        metrics: {
+          increment: (name: string, labels: any, value?: number) => metricsCalls.push({ name, labels, value }),
+          decrement: () => {},
+          observe: () => {}
+        }
+      } as any
+      result = await checkAssetCache(components, {
+        entity: { content: [{ file: 'a.glb', hash: 'h' }] } as any,
+        abVersion: 'v48',
+        buildTarget: 'windows',
+        cdnBucket: 'bucket',
+        depsDigestByHash: new Map([['h', computeDepsDigest([])]])
+      })
+    })
+
+    it('should treat the asset as a miss without throwing', () => {
+      expect(result.missingHashes).toEqual(['h'])
+      expect(result.cachedHashes).toEqual([])
+    })
+
+    it('should emit an exhausted counter', () => {
+      const exhausted = metricsCalls.find(
+        (m) => m.name === 'ab_converter_s3_head_errors_total' && m.labels.retry_outcome === 'exhausted'
+      )
+      expect(exhausted).toBeDefined()
+    })
+  })
+
+  describe('and S3 returns a non-retryable error (e.g. AccessDenied)', () => {
+    let metricsCalls: Array<{ name: string; labels: any; value?: number }>
+    let result: AssetCacheResult
+    let headCallCount: number
+
+    beforeEach(async () => {
+      headCallCount = 0
+      const s3: any = {
+        headObject: () => ({
+          promise: async () => {
+            headCallCount++
+            const err: any = new Error('forbidden')
+            err.statusCode = 403
+            err.code = 'AccessDenied'
+            throw err
+          }
+        })
+      }
+      const { logger } = makeMockLogger()
+      metricsCalls = []
+      const components = {
+        cdnS3: s3,
+        logs: { getLogger: () => logger },
+        metrics: {
+          increment: (name: string, labels: any, value?: number) => metricsCalls.push({ name, labels, value }),
+          decrement: () => {},
+          observe: () => {}
+        }
+      } as any
+      result = await checkAssetCache(components, {
+        entity: { content: [{ file: 'a.glb', hash: 'h' }] } as any,
+        abVersion: 'v48',
+        buildTarget: 'windows',
+        cdnBucket: 'bucket',
+        depsDigestByHash: new Map([['h', computeDepsDigest([])]])
+      })
+    })
+
+    it('should NOT retry — burning the attempt budget on AccessDenied is wasted work', () => {
+      expect(headCallCount).toBe(1)
+    })
+
+    it('should mark the asset as missing and emit an exhausted counter', () => {
+      expect(result.missingHashes).toEqual(['h'])
+      const exhausted = metricsCalls.find(
+        (m) => m.name === 'ab_converter_s3_head_errors_total' && m.labels.retry_outcome === 'exhausted'
+      )
+      expect(exhausted).toBeDefined()
     })
   })
 


### PR DESCRIPTION
## Summary
- A single transient 5xx HEAD used to reject the whole `Promise.all` fan-out and tip the conversion to the legacy Unity-rebuild path. Each HEAD now has its own retry loop with equal-jitter exponential backoff; after exhaustion the asset is treated as a miss rather than failing the whole probe.
- Worst case for a hot key is Unity rebuilds one bundle, not a lost short-circuit on dozens of healthy assets.
- New metric `ab_converter_s3_head_errors_total{retry_outcome=retried|exhausted}` flags S3 flakiness before it escalates into Unity-fallback cost.

## Test plan
- [ ] `yarn test` passes (three new unit tests cover transient-recovers, exhausted, non-retryable; existing "propagate the error" test updated to reflect the new contract)
- [ ] Inject a `mock-aws-s3` 503; conversion still succeeds via the per-asset miss fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)