### PR TITLE
feat: hoist Unity Resources.UnloadUnusedAssets out of per-GLTF finally

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -424,13 +424,17 @@ namespace DCL.ABConverter
                     assetsToMark.Remove(gltf.AssetPath);
                     continue;
                 }
-                finally
-                {
-                    await Resources.UnloadUnusedAssets();
-                }
 
                 totalGltfsProcessed++;
             }
+
+            // Resources.UnloadUnusedAssets sweeps the entire asset graph + forces
+            // a GC pass and is one of Unity's most expensive editor APIs (100ms+
+            // each call on a non-trivial project). It used to run in a per-GLTF
+            // finally, paying that cost N times per scene (20-50 GLTFs is
+            // typical). Hoisted to a single call after the import loop so the
+            // sweep amortises across the whole scene.
+            await Resources.UnloadUnusedAssets();
 
             EditorUtility.ClearProgressBar();
 


### PR DESCRIPTION
## Summary
- `Resources.UnloadUnusedAssets()` (one of Unity's most expensive editor APIs — full asset graph sweep + GC pass, typically 100ms+ per call) ran in the per-iteration `finally` of the GLTF import loop. A 20–50 GLTF scene paid that cost 20–50 times.
- Hoisted to a single call after the loop. Per-iteration cleanup of `assetsToMark.Remove` and the error/continue paths stay where they are.

## Risk
Very large scenes that previously benefited from incremental unloads to keep editor memory bounded might now peak higher. If memory pressure shows up, the follow-up is a periodic-unload hint (every N iterations) rather than reverting fully.

## Test plan
- [ ] CI e2e conversion (`ci-editmode-test.sh`) passes
- [ ] `test-conversion.js` against a representative scene completes with no OOM regression
- [ ] Compare Unity log timestamps before/after — the cumulative unload time should drop materially

🤖 Generated with [Claude Code](https://claude.com/claude-code)