### PR TITLE
feat: consolidate Unity per-GLTF animator SaveAssets+Refresh into one trailing flush

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -432,6 +432,14 @@ namespace DCL.ABConverter
                 totalGltfsProcessed++;
             }
 
+            // Single trailing flush for animator-controller writes that the
+            // per-GLTF Create*AnimatorController paths used to do individually.
+            // The animator assets accumulate as unsaved sub-asset modifications
+            // across the loop; serialising them once at the end replaces N full
+            // project rescans with one.
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+
             EditorUtility.ClearProgressBar();
 
             log.Info("Ended importing GLTFs");
@@ -559,8 +567,10 @@ namespace DCL.ABConverter
                 }
             }
 
-            AssetDatabase.SaveAssets();
-            AssetDatabase.Refresh();
+            // Animator controller writes are deferred to the post-loop refresh in
+            // ProcessAllGltfs — the controller asset isn't read again during this
+            // GLTF's own processing, so a per-GLTF SaveAssets+Refresh just paid
+            // a full project rescan tax for no consumer.
         }
 
         private void CreateAnimatorController(IGltfImport gltfImport, string directory)
@@ -618,8 +628,8 @@ namespace DCL.ABConverter
                 loopBackTransition.hasExitTime = true;
             }
 
-            AssetDatabase.SaveAssets();
-            AssetDatabase.Refresh();
+            // Animator controller writes are deferred to the post-loop refresh in
+            // ProcessAllGltfs — see the layered variant for rationale.
         }
 
         private AnimationMethod GetAnimationMethod(bool isEmote, bool isWearable)


### PR DESCRIPTION
## Summary
- `CreateAnimatorController` and `CreateLayeredAnimatorController` each ended with `AssetDatabase.SaveAssets()` + `AssetDatabase.Refresh()` — a full project rescan + GC pass per GLTF that had animations. Eliminates that per-iteration cost in favour of a single trailing flush after the GLTF import loop.
- Material extraction's `RefreshAssetsWithNoLogs` at the end of `ExtractEmbedMaterialsFromGltf` is intentionally kept — the GLTF importer's `ConfigureImporter` on the next iteration needs the material assets present on disk, so deferring there would break the import chain.

## Risk
The animator-controller asset isn't consumed during its own GLTF's processing (only at bundle build time), so the deferral is safe by inspection. Revert is a one-line restore if any consumer turns out to need the asset on disk mid-loop.

## Test plan
- [ ] CI e2e conversion passes
- [ ] `test-conversion.js` against an emote (exercises animator controller) produces byte-identical bundle output before/after
- [ ] Compare Unity log timestamps — refresh-pass cumulative time should drop on emote-heavy scenes

🤖 Generated with [Claude Code](https://claude.com/claude-code)