### PR TITLE
feat: deterministic asset bundle GUIDs

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -39,7 +39,7 @@ namespace DCL.ABConverter
         private const float DEFAULT_MAX_TEXTURE_SIZE = 512f;
         private const float DESKTOP_MAX_TEXTURE_SIZE = 1024f;
 
-        private const string VERSION = "7.0";
+        private const string VERSION = "8.0";
         private const string LOOP_PARAMETER = "Loop";
 
         private readonly Dictionary<string, string> lowerCaseHashes = new ();
@@ -338,7 +338,7 @@ namespace DCL.ABConverter
 
                     string directory = Path.GetDirectoryName(relativePath);
 
-                    if (textures.Count > 0) { textures = ExtractEmbedTexturesFromGltf(textures, gltfImport, directory); }
+                    if (textures.Count > 0) { textures = ExtractEmbedTexturesFromGltf(textures, gltfImport, directory, gltf.AssetPath.hash); }
 
                     embedExtractTextureTime.Stop();
 
@@ -349,9 +349,9 @@ namespace DCL.ABConverter
                     if (animationMethod == AnimationMethod.Mecanim)
                     {
                         if (isEmote)
-                            CreateAnimatorController(gltfImport, directory);
+                            CreateAnimatorController(gltfImport, directory, gltf.AssetPath.hash);
                         else
-                            CreateLayeredAnimatorController(gltfImport, directory);
+                            CreateLayeredAnimatorController(gltfImport, directory, gltf.AssetPath.hash);
                     }
 
                     log.Verbose($"Importing {relativePath}");
@@ -384,6 +384,7 @@ namespace DCL.ABConverter
                         continue;
                     }
 
+                    SetDeterministicAssetDatabaseGuid(gltf.AssetPath);
                     if ((!settings.createAssetBundle || !settings.visualTest) && settings.placeOnScene)
                     {
                         GameObject originalGltf = env.assetDatabase.LoadAssetAtPath<GameObject>(relativePath);
@@ -437,7 +438,7 @@ namespace DCL.ABConverter
             log.Info("Ended importing GLTFs");
         }
 
-        private void CreateLayeredAnimatorController(IGltfImport gltfImport, string directory)
+        private void CreateLayeredAnimatorController(IGltfImport gltfImport, string directory, string ownerGltfHash)
         {
             var clips = gltfImport.GetClips();
             if (clips == null) return;
@@ -561,9 +562,12 @@ namespace DCL.ABConverter
 
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
+            SetDeterministicGuid(filePath, $"{ownerGltfHash}/animatorController");
+            SetDeterministicSubAssetIds(filePath, $"{ownerGltfHash}/animatorController");
+            SetDeterministicTosOrder(filePath);
         }
 
-        private void CreateAnimatorController(IGltfImport gltfImport, string directory)
+        private void CreateAnimatorController(IGltfImport gltfImport, string directory, string ownerGltfHash)
         {
             var clips = gltfImport.GetClips();
             if (clips == null) return;
@@ -620,6 +624,9 @@ namespace DCL.ABConverter
 
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
+            SetDeterministicGuid(filePath, $"{ownerGltfHash}/animatorController");
+            SetDeterministicSubAssetIds(filePath, $"{ownerGltfHash}/animatorController");
+            SetDeterministicTosOrder(filePath);
         }
 
         private AnimationMethod GetAnimationMethod(bool isEmote, bool isWearable)
@@ -645,13 +652,13 @@ namespace DCL.ABConverter
             if (gltfImport.defaultMaterial != null)
             {
                 var mat = gltfImport.defaultMaterial;
-                CreateMaterialAsset(mat, materialDirectory, texNameMap);
+                CreateMaterialAsset(mat, materialDirectory, texNameMap, gltf.AssetPath.hash);
             }
 
             for (var t = 0; t < gltfImport.MaterialCount; t++)
             {
                 var originalMaterial = gltfImport.GetMaterial(t);
-                CreateMaterialAsset(originalMaterial, materialDirectory, texNameMap);
+                CreateMaterialAsset(originalMaterial, materialDirectory, texNameMap, gltf.AssetPath.hash);
             }
 
             Profiler.EndSample();
@@ -659,7 +666,7 @@ namespace DCL.ABConverter
             RefreshAssetsWithNoLogs();
         }
 
-        private void CreateMaterialAsset(Material originalMaterial, string materialRoot, Dictionary<string, Texture2D> texNameMap)
+        private void CreateMaterialAsset(Material originalMaterial, string materialRoot, Dictionary<string, Texture2D> texNameMap, string ownerGltfHash)
         {
             string matName = Utils.NicifyName(originalMaterial.name);
 
@@ -701,6 +708,7 @@ namespace DCL.ABConverter
             Profiler.EndSample();
 
             EditorUtility.SetDirty(newMaterial);
+            SetDeterministicGuid(string.Concat(materialRoot, matName, ".mat"), $"{ownerGltfHash}/material/{matName}");
         }
 
         private List<int> GetTextureProperties(Shader shader)
@@ -741,7 +749,7 @@ namespace DCL.ABConverter
 
 
 
-        private List<Texture2D> ExtractEmbedTexturesFromGltf(List<Texture2D> textures, IGltfImport gltfImport, string folderName)
+        private List<Texture2D> ExtractEmbedTexturesFromGltf(List<Texture2D> textures, IGltfImport gltfImport, string folderName, string ownerGltfHash)
         {
             var newTextures = new List<Texture2D>();
 
@@ -850,6 +858,7 @@ namespace DCL.ABConverter
 
                     ReduceTextureSizeIfNeeded(texPath, maxTextureSize);
 
+                    SetDeterministicGuid(texPath, $"{ownerGltfHash}/texture/{texName}");
                     newTextures.Add(env.assetDatabase.LoadAssetAtPath<Texture2D>(texPath));
                 }
             }
@@ -1032,6 +1041,14 @@ namespace DCL.ABConverter
             env.assetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport | ImportAssetOptions.ForceUpdate);
 
             env.assetDatabase.SaveAssets();
+
+            foreach (string metadataAssetHash in new HashSet<string>(bundleNameToHash.Values))
+            {
+                if (string.IsNullOrEmpty(metadataAssetHash)) continue;
+                string metadataPath = $"{finalDownloadedPath}/{metadataAssetHash}/metadata.json";
+                if (env.file.Exists(metadataPath))
+                    SetDeterministicGuid(metadataPath, $"{metadataAssetHash}/metadata");
+            }
 
             var afterMetadataRefresh = EditorApplication.timeSinceStartup;
 
@@ -1517,34 +1534,60 @@ namespace DCL.ABConverter
         /// </summary>
         /// <param name="assetPath">AssetPath of the target asset to modify</param>
         private void SetDeterministicAssetDatabaseGuid(AssetPath assetPath)
+            => SetDeterministicGuid(assetPath.finalPath, assetPath.hash);
+
+        private void SetDeterministicGuid(string assetFinalPath, string seed)
         {
-            string metaPath = env.assetDatabase.GetTextMetaFilePathFromAssetPath(assetPath.finalPath);
+            string metaPath = env.assetDatabase.GetTextMetaFilePathFromAssetPath(assetFinalPath);
 
             env.assetDatabase.ReleaseCachedFileHandles();
 
             string metaContent = env.file.ReadAllText(metaPath);
-            string guid = Utils.CidToGuid(assetPath.hash);
+            string guid = Utils.CidToGuid(seed);
             string newMetaContent = Regex.Replace(metaContent, @"guid: \w+?\n", $"guid: {guid}\n");
+
+            // Per-call unique scratch path so overlapping/concurrent calls can't clobber
+            // each other. This file is temporary (copied out then deleted, never bundled),
+            // so its name has no effect on deterministic output.
+            string tmpPath = finalDownloadedPath + "tmp_" + guid;
 
             //NOTE(Brian): We must do this hack in order to the new guid to be added to the AssetDatabase.
             //             on windows, an AssetImporter.SaveAndReimport call makes the trick, but this won't work
             //             on Unix based OSes for some reason.
             env.file.Delete(metaPath);
 
-            env.file.Copy(assetPath.finalPath, finalDownloadedPath + "tmp");
-            env.assetDatabase.DeleteAsset(assetPath.finalPath);
-            env.file.Delete(assetPath.finalPath);
+            env.file.Copy(assetFinalPath, tmpPath);
+            env.assetDatabase.DeleteAsset(assetFinalPath);
+            env.file.Delete(assetFinalPath);
 
             env.assetDatabase.Refresh();
             env.assetDatabase.SaveAssets();
 
-            env.file.Copy(finalDownloadedPath + "tmp", assetPath.finalPath);
+            env.file.Copy(tmpPath, assetFinalPath);
             env.file.WriteAllText(metaPath, newMetaContent);
-            env.file.Delete(finalDownloadedPath + "tmp");
-            env.file.Delete(finalDownloadedPath + "tmp.meta");
+            if (env.file.Exists(tmpPath)) env.file.Delete(tmpPath);
+            if (env.file.Exists(tmpPath + ".meta")) env.file.Delete(tmpPath + ".meta");
 
             env.assetDatabase.Refresh();
             env.assetDatabase.SaveAssets();
+        }
+
+        private void SetDeterministicSubAssetIds(string assetFinalPath, string seed)
+            => env.file.WriteAllText(assetFinalPath, DeterministicYaml.RemapSubAssetIds(env.file.ReadAllText(assetFinalPath), seed));
+
+        /// <summary>
+        /// Canonicalizes the iteration order of the AnimatorController's m_TOS map
+        /// (the transform-of-string table: CRC32 hash -> string path/state name).
+        /// See DeterministicYaml.ReorderTosOrder for the full rationale and the
+        /// structured-rewrite implementation. Only rewrites the file when the order
+        /// actually changed (ReorderTosOrder returns the same string instance otherwise).
+        /// </summary>
+        private void SetDeterministicTosOrder(string assetFinalPath)
+        {
+            string txt = env.file.ReadAllText(assetFinalPath);
+            string outp = DeterministicYaml.ReorderTosOrder(txt);
+            if (!ReferenceEquals(outp, txt))
+                env.file.WriteAllText(assetFinalPath, outp);
         }
 
         /// <summary>

--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleMetadataBuilder.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleMetadataBuilder.cs
@@ -1,5 +1,4 @@
 using AssetBundleConverter.Wrappers.Interfaces;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -11,10 +10,12 @@ namespace DCL.ABConverter
 {
     public static class AssetBundleMetadataBuilder
     {
+        public const long DETERMINISTIC_TIMESTAMP = 0L;
+
         public static void GenerateLODMetadata(string path, string[] dependencies,
             string mainAsset, string lodName)
         {
-            var metadata = new AssetBundleMetadata { timestamp = DateTime.UtcNow.Ticks, mainAsset = mainAsset, dependencies = dependencies};
+            var metadata = new AssetBundleMetadata { timestamp = DETERMINISTIC_TIMESTAMP, mainAsset = mainAsset, dependencies = dependencies};
             string json = JsonUtility.ToJson(metadata);
             System.IO.File.WriteAllText(path + $"/{lodName}/metadata.json", json);
         }
@@ -33,7 +34,7 @@ namespace DCL.ABConverter
                 if (string.IsNullOrEmpty(assetBundles[i]))
                     continue;
 
-                var metadata = new AssetBundleMetadata { version = version, timestamp = DateTime.UtcNow.Ticks };
+                var metadata = new AssetBundleMetadata { version = version, timestamp = DETERMINISTIC_TIMESTAMP };
                 string[] deps = manifest.GetAllDependencies(assetBundles[i]);
 
                 if (deps.Length > 0)

--- a/asset-bundle-converter/Assets/AssetBundleConverter/DeterministicYaml.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/DeterministicYaml.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace DCL.ABConverter
+{
+    /// <summary>
+    /// Pure (file-IO-free) text transforms used to make serialized Unity asset YAML
+    /// deterministic across conversions. Extracted from AssetBundleConverter so the
+    /// transforms can be tested in isolation; the logic is byte-for-byte identical to
+    /// the original inline implementations.
+    /// </summary>
+    public static class DeterministicYaml
+    {
+        public static string RemapSubAssetIds(string yaml, string seed)
+        {
+            string txt = yaml;
+
+            // Unity writes the YAML docs in ascending original-localID order, and
+            // those localIDs are a per-session random draw — so a positional index
+            // is NOT deterministic across conversions. Sort the docs by content
+            // (classID, m_Name, body) and index in that order instead. Only the
+            // embedded AnimationClip docs surface as bundle objects, and class 74
+            // sorts before the state/transition classes, so clips always take the
+            // first indices in name order. Docs with identical keys are mutually
+            // interchangeable (identical bodies), so any stable order is byte-equal.
+            var docs = new List<(int classId, long oldId, string name, string body)>();
+            var headers = Regex.Matches(txt, @"^--- !u!(\d+) &(-?\d+)", RegexOptions.Multiline);
+
+            for (int i = 0; i < headers.Count; i++)
+            {
+                Match m = headers[i];
+                long oldId = long.Parse(m.Groups[2].Value);
+                // Skip Unity built-in / global object IDs: those are small, stable
+                // localIDs (script refs, importers, ...) that are already deterministic.
+                // Only the large, per-session-random sub-asset localIDs (>=10M) get remapped.
+                if (Math.Abs(oldId) < 10_000_000) continue;
+                int bodyStart = m.Index + m.Length;
+                int bodyEnd = i + 1 < headers.Count ? headers[i + 1].Index : txt.Length;
+                string body = txt.Substring(bodyStart, bodyEnd - bodyStart);
+                string name = Regex.Match(body, @"^  m_Name: (.*)$", RegexOptions.Multiline).Groups[1].Value;
+                docs.Add((int.Parse(m.Groups[1].Value), oldId, name, body));
+            }
+
+            docs.Sort((a, b) =>
+            {
+                int c = a.classId.CompareTo(b.classId);
+                if (c != 0) return c;
+                c = string.CompareOrdinal(a.name, b.name);
+                return c != 0 ? c : string.CompareOrdinal(a.body, b.body);
+            });
+
+            var ids = new Dictionary<long, long>();
+            int idx = 0;
+
+            foreach (var doc in docs)
+            {
+                if (ids.ContainsKey(doc.oldId)) continue;
+                byte[] h = Utils.md5.ComputeHash(System.Text.Encoding.UTF8.GetBytes($"{seed}/{idx++}"));
+                ids[doc.oldId] = BitConverter.ToInt64(h, 0);
+            }
+
+            // Single-pass replacement keyed on the captured id: rewrite each
+            // matched id by dictionary lookup. Doing it per-id with sequential
+            // Regex.Replace calls on the mutating text risks cascading
+            // corruption (a freshly assigned id colliding with an original id
+            // not yet rewritten); one pass is also O(fileSize), not O(ids*fileSize).
+            txt = Regex.Replace(txt, @"&(-?\d+)\b",
+                m => ids.TryGetValue(long.Parse(m.Groups[1].Value), out long id) ? $"&{id}" : m.Value);
+            txt = Regex.Replace(txt, @"fileID: (-?\d+)\b",
+                m => ids.TryGetValue(long.Parse(m.Groups[1].Value), out long id) ? $"fileID: {id}" : m.Value);
+            return txt;
+        }
+
+        /// <summary>
+        /// Canonicalizes the iteration order of the AnimatorController's m_TOS map
+        /// (the transform-of-string table: CRC32 hash -> string path/state name).
+        ///
+        /// Unity's native mecanim builder fills m_TOS in the iteration order of an
+        /// engine-internal hash container, so the serialized order is a per-build
+        /// permutation that is *not* a function of the recorded CRC keys and is not
+        /// reproducible offline. m_TOS is a pure lookup table — consumers always
+        /// index it by hash and never rely on iteration order — so rewriting the
+        /// order is byte-neutral semantically. We re-emit the entries sorted ascending
+        /// by their CRC32 key, which is the canonical order the downstream converter
+        /// expects, so the built bundle's m_TOS matches that reference by construction.
+        ///
+        /// Same mechanism/phase as RemapSubAssetIds: a structured rewrite
+        /// of the already-serialized .controller text, run after SaveAssets/Refresh
+        /// and before BuildAssetBundles. Scope is naturally limited to AnimatorController
+        /// docs (only they carry m_TOS).
+        ///
+        /// In editor YAML, m_TOS serializes either as a mapping
+        ///     m_TOS:
+        ///       0:&lt;path&gt;
+        ///       23966416: Loop
+        /// or (depending on type-tree flags) as a sequence of first/second pairs
+        ///     m_TOS:
+        ///     - first: 0
+        ///       second: &lt;path&gt;
+        /// Both forms are handled.
+        ///
+        /// Returns the input string instance unchanged (same reference) when no
+        /// reorder was needed, so callers can skip the file write via ReferenceEquals.
+        /// </summary>
+        public static string ReorderTosOrder(string yaml)
+        {
+            string txt = yaml;
+
+            // Split into physical lines, preserving each line's own terminator so the
+            // rewrite is byte-faithful (CRLF/LF mixes survive untouched).
+            var lines = SplitKeepEol(txt);
+
+            bool changed = false;
+            int i = 0;
+            while (i < lines.Count)
+            {
+                // Find a "  m_TOS:" header line (a key whose value is on following lines).
+                var hdr = Regex.Match(StripEol(lines[i]), @"^(?<indent>[ \t]*)m_TOS:[ \t]*$");
+                if (!hdr.Success) { i++; continue; }
+
+                string indent = hdr.Groups["indent"].Value;
+                int bodyStart = i + 1;
+                int bodyEnd = bodyStart;
+
+                // The block body is every following line that is part of the m_TOS
+                // value: a deeper-indented line (mapping entries / "second:" continuation)
+                // OR a sequence item ("- ...") at the header indent. Stops at the first
+                // sibling key (same indent, not a sequence item) or shallower line.
+                while (bodyEnd < lines.Count)
+                {
+                    string raw = StripEol(lines[bodyEnd]);
+                    if (raw.Length == 0) break; // blank line ends the block defensively
+                    string lead = Regex.Match(raw, @"^[ \t]*").Value;
+                    bool isSeqItem = Regex.IsMatch(raw, @"^[ \t]*-");
+                    bool deeper = lead.Length > indent.Length;
+                    bool seqAtIndent = isSeqItem && lead.Length == indent.Length;
+                    if (deeper || seqAtIndent) { bodyEnd++; continue; }
+                    break;
+                }
+
+                if (bodyEnd == bodyStart) { i = bodyEnd; continue; } // empty m_TOS block
+
+                // Group the body lines into entries. Each entry starts at either a
+                // sequence item ("- first: <crc>") or a mapping line ("<crc>: <value>"),
+                // and includes any following continuation lines (e.g. "  second: ...").
+                var entries = new List<(uint crc, List<string> lns)>();
+                bool parseable = true;
+                int j = bodyStart;
+                while (j < bodyEnd)
+                {
+                    string raw = StripEol(lines[j]);
+                    // sequence form: "- first: <crc>"
+                    var seq = Regex.Match(raw, @"^[ \t]*-[ \t]*first:[ \t]*(\d+)[ \t]*$");
+                    // mapping form: "<crc>: <value>"
+                    var map = Regex.Match(raw, @"^[ \t]*(\d+):");
+                    uint crc;
+                    if (seq.Success) crc = uint.Parse(seq.Groups[1].Value);
+                    else if (map.Success) crc = uint.Parse(map.Groups[1].Value);
+                    else { parseable = false; break; }
+
+                    var group = new List<string> { lines[j] };
+                    int k = j + 1;
+                    // absorb continuation lines (no new entry header) until the next
+                    // entry header or the end of the block.
+                    while (k < bodyEnd)
+                    {
+                        string r2 = StripEol(lines[k]);
+                        bool nextIsSeq = Regex.IsMatch(r2, @"^[ \t]*-[ \t]*first:");
+                        bool nextIsMap = Regex.IsMatch(r2, @"^[ \t]*\d+:");
+                        if (nextIsSeq || nextIsMap) break;
+                        group.Add(lines[k]);
+                        k++;
+                    }
+                    entries.Add((crc, group));
+                    j = k;
+                }
+
+                if (!parseable || entries.Count == 0) { i = bodyEnd; continue; }
+
+                // Stable-sort ascending by CRC32 key (OrderBy is stable).
+                var sorted = entries.OrderBy(e => e.crc).ToList();
+
+                // Only rewrite if the order actually changed.
+                bool reordered = false;
+                for (int t = 0; t < entries.Count; t++)
+                    if (entries[t].crc != sorted[t].crc) { reordered = true; break; }
+
+                if (reordered)
+                {
+                    var rebuilt = new List<string>();
+                    foreach (var e in sorted) rebuilt.AddRange(e.lns);
+                    lines.RemoveRange(bodyStart, bodyEnd - bodyStart);
+                    lines.InsertRange(bodyStart, rebuilt);
+                    changed = true;
+                }
+
+                i = bodyStart + entries.SelectMany(e => e.lns).Count();
+            }
+
+            if (changed)
+                return string.Concat(lines);
+
+            return yaml;
+        }
+
+        // Splits text into lines, each retaining its trailing EOL ("\r\n", "\n", or
+        // none for a final unterminated line). Concatenating the result reproduces the
+        // input exactly.
+        private static List<string> SplitKeepEol(string txt)
+        {
+            var result = new List<string>();
+            int start = 0;
+            for (int i = 0; i < txt.Length; i++)
+            {
+                if (txt[i] == '\n')
+                {
+                    result.Add(txt.Substring(start, i - start + 1));
+                    start = i + 1;
+                }
+            }
+            if (start < txt.Length) result.Add(txt.Substring(start));
+            return result;
+        }
+
+        private static string StripEol(string line) => line.TrimEnd('\r', '\n');
+    }
+}

--- a/asset-bundle-converter/Assets/AssetBundleConverter/DeterministicYaml.cs.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/DeterministicYaml.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2e1692792c84b3783037854d6289f04
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/asset-bundle-converter/Assets/AssetBundleConverter/LODsConverter/Scripts/LODConversion.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/LODsConverter/Scripts/LODConversion.cs
@@ -644,7 +644,7 @@ public class LODConversion
             {
                 var metadata = new AssetBundleMetadata
                 {
-                    timestamp = DateTime.UtcNow.Ticks,
+                    timestamp = AssetBundleMetadataBuilder.DETERMINISTIC_TIMESTAMP,
                     mainAsset = $"{lodName}.prefab",
                     dependencies = deps
                 };

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Tests/AssetBundleMetadataBuilderShould.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Tests/AssetBundleMetadataBuilderShould.cs
@@ -53,7 +53,7 @@ namespace AssetBundleConverter.Tests
             file.Received(1).WriteAllText(METADATA_PATH, Arg.Any<string>());
             var metadata = ParseCaptured();
             Assert.AreEqual(VERSION, metadata.version);
-            Assert.Greater(metadata.timestamp, 0);
+            Assert.AreEqual(0, metadata.timestamp);
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace AssetBundleConverter.Tests
             file.Received(1).WriteAllText(METADATA_PATH, Arg.Any<string>());
             var metadata = ParseCaptured();
             Assert.AreEqual(VERSION, metadata.version);
-            Assert.Greater(metadata.timestamp, 0);
+            Assert.AreEqual(0, metadata.timestamp);
         }
 
         [Test]

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Tests/DeterministicYamlShould.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Tests/DeterministicYamlShould.cs
@@ -1,0 +1,383 @@
+using System.Text.RegularExpressions;
+using DCL.ABConverter;
+using NUnit.Framework;
+
+namespace AssetBundleConverter.Tests
+{
+    [TestFixture]
+    [Category("EditModeCI")]
+    public class UtilsCidToGuidShould
+    {
+        private const string CID_A = "bafkreiaie6ke72c3mfq3w5lhrgw6vy2f4u6kymhd66jxgi7baanyutsira";
+        private const string CID_B = "bafkreibuffer000000000000000000000000000000000000000000000000";
+
+        [Test]
+        public void ProduceIdenticalGuidForSameCid()
+        {
+            Assert.AreEqual(Utils.CidToGuid(CID_A), Utils.CidToGuid(CID_A));
+        }
+
+        [Test]
+        public void ProduceDifferentGuidForDifferentCids()
+        {
+            Assert.AreNotEqual(Utils.CidToGuid(CID_A), Utils.CidToGuid(CID_B));
+        }
+
+        [Test]
+        public void Produce32HexCharacters()
+        {
+            Assert.AreEqual(32, Utils.CidToGuid(CID_A).Length);
+        }
+
+        [Test]
+        public void ProduceLowercaseHexOnly()
+        {
+            Assert.IsTrue(Regex.IsMatch(Utils.CidToGuid(CID_A), "^[0-9a-f]{32}$"));
+        }
+
+        [Test]
+        public void MatchManualMd5HexEncoding()
+        {
+            byte[] data = Utils.md5.ComputeHash(System.Text.Encoding.UTF8.GetBytes(CID_A));
+            var sb = new System.Text.StringBuilder();
+            foreach (byte b in data) sb.Append(b.ToString("x2"));
+
+            Assert.AreEqual(sb.ToString(), Utils.CidToGuid(CID_A));
+        }
+    }
+
+    [TestFixture]
+    [Category("EditModeCI")]
+    public class DeterministicYamlRemapSubAssetIdsShould
+    {
+        private const string SEED = "QmHash/animatorController";
+        private const string OTHER_SEED = "QmOther/animatorController";
+
+        // Realistic .controller / embedded .anim YAML. Two AnimationClip docs
+        // (class 74) named "AAA" and "ZZZ" plus the AnimatorController (class 91).
+        // The controller references the clips by their localID via {fileID: <id>}.
+        // Built-in ids (e.g. 11500000) and small ids must survive untouched.
+        private const string CLIP_AAA =
+            "--- !u!74 &7400000000000000001\n" +
+            "AnimationClip:\n" +
+            "  m_Name: AAA\n" +
+            "  m_ObjectHideFlags: 0\n";
+
+        private const string CLIP_ZZZ =
+            "--- !u!74 &7400000000000000002\n" +
+            "AnimationClip:\n" +
+            "  m_Name: ZZZ\n" +
+            "  m_ObjectHideFlags: 0\n";
+
+        private const string CONTROLLER =
+            "--- !u!91 &9100000000000000001\n" +
+            "AnimatorController:\n" +
+            "  m_Name: MyController\n" +
+            "  m_AnimationClips:\n" +
+            "  - {fileID: 7400000000000000001}\n" +
+            "  - {fileID: 7400000000000000002}\n" +
+            "  m_DefaultClip: {fileID: 11500000}\n";
+
+        private const string YAML_HEADER =
+            "%YAML 1.1\n" +
+            "%TAG !u! tag:unity3d.com,2011:\n";
+
+        private string yamlAaaFirst;
+        private string yamlZzzFirst;
+
+        [SetUp]
+        public void Setup()
+        {
+            yamlAaaFirst = YAML_HEADER + CONTROLLER + CLIP_AAA + CLIP_ZZZ;
+            yamlZzzFirst = YAML_HEADER + CONTROLLER + CLIP_ZZZ + CLIP_AAA;
+        }
+
+        private static string AnchorFor(string yaml, string name)
+        {
+            // Returns the &<id> anchor of the doc whose m_Name is <name>.
+            var match = Regex.Match(
+                yaml,
+                @"&(-?\d+)\n[A-Za-z]+:\n  m_Name: " + Regex.Escape(name) + "\n");
+            Assert.IsTrue(match.Success, $"Could not find anchor for clip '{name}'");
+            return match.Groups[1].Value;
+        }
+
+        [Test]
+        public void ProduceByteIdenticalOutputForSameInputAndSeed()
+        {
+            string a = DeterministicYaml.RemapSubAssetIds(yamlAaaFirst, SEED);
+            string b = DeterministicYaml.RemapSubAssetIds(yamlAaaFirst, SEED);
+
+            Assert.AreEqual(a, b);
+        }
+
+        [Test]
+        public void ProduceStableOutputWhenCalledTwiceOnAlreadyRemappedText()
+        {
+            string once = DeterministicYaml.RemapSubAssetIds(yamlAaaFirst, SEED);
+            string twice = DeterministicYaml.RemapSubAssetIds(once, SEED);
+
+            // The freshly assigned ids are derived from md5 and are large/negative,
+            // so a second pass re-derives the same mapping for the same content order.
+            Assert.AreEqual(once, twice);
+        }
+
+        [Test]
+        public void ProduceDifferentIdsForDifferentSeed()
+        {
+            string withSeed = DeterministicYaml.RemapSubAssetIds(yamlAaaFirst, SEED);
+            string withOther = DeterministicYaml.RemapSubAssetIds(yamlAaaFirst, OTHER_SEED);
+
+            Assert.AreNotEqual(withSeed, withOther);
+        }
+
+        [Test]
+        public void PreserveBuiltInFileId11500000()
+        {
+            string result = DeterministicYaml.RemapSubAssetIds(yamlAaaFirst, SEED);
+
+            Assert.IsTrue(result.Contains("m_DefaultClip: {fileID: 11500000}"));
+        }
+
+        [Test]
+        public void PreserveSmallIdsBelowThreshold()
+        {
+            // ids with Math.Abs(id) < 10_000_000 are never remapped.
+            string yaml = YAML_HEADER +
+                          "--- !u!91 &100\n" +
+                          "AnimatorController:\n" +
+                          "  m_Name: Small\n" +
+                          "  ref: {fileID: 100}\n";
+
+            string result = DeterministicYaml.RemapSubAssetIds(yaml, SEED);
+
+            Assert.AreEqual(yaml, result);
+        }
+
+        [Test]
+        public void RewriteAnchorAndAllReferencesToTheSameNewId()
+        {
+            string result = DeterministicYaml.RemapSubAssetIds(yamlAaaFirst, SEED);
+
+            // AAA's anchor and the controller's reference to it must agree.
+            string aaaAnchor = AnchorFor(result, "AAA");
+            Assert.IsTrue(result.Contains("- {fileID: " + aaaAnchor + "}"),
+                "Reference to AAA was not rewritten to match its new anchor");
+        }
+
+        [Test]
+        public void LeaveNoDanglingReferenceToOldIds()
+        {
+            string result = DeterministicYaml.RemapSubAssetIds(yamlAaaFirst, SEED);
+
+            // The original large localIDs must be gone from both anchors and refs.
+            Assert.IsFalse(
+                result.Contains("7400000000000000001") || result.Contains("7400000000000000002"),
+                "Old localIDs still present after remap");
+        }
+
+        [Test]
+        public void PreserveTheNumberOfYamlDocuments()
+        {
+            int before = Regex.Matches(yamlAaaFirst, @"^--- !u!", RegexOptions.Multiline).Count;
+            string result = DeterministicYaml.RemapSubAssetIds(yamlAaaFirst, SEED);
+            int after = Regex.Matches(result, @"^--- !u!", RegexOptions.Multiline).Count;
+
+            Assert.AreEqual(before, after);
+        }
+
+        [Test]
+        public void PreserveNonIdTextSuchAsNamesAndClassTags()
+        {
+            string result = DeterministicYaml.RemapSubAssetIds(yamlAaaFirst, SEED);
+
+            Assert.IsTrue(
+                result.Contains("--- !u!74 ") &&
+                result.Contains("--- !u!91 ") &&
+                result.Contains("m_Name: AAA") &&
+                result.Contains("m_Name: ZZZ") &&
+                result.Contains("m_Name: MyController"));
+        }
+
+        [Test]
+        public void AssignTheSameIdToTheSameNamedClipRegardlessOfInputOrder()
+        {
+            // The whole point of content-sorted indexing: the new id for "AAA" must
+            // be identical whether AAA's doc appears before or after ZZZ's in input.
+            string resultAaaFirst = DeterministicYaml.RemapSubAssetIds(yamlAaaFirst, SEED);
+            string resultZzzFirst = DeterministicYaml.RemapSubAssetIds(yamlZzzFirst, SEED);
+
+            Assert.AreEqual(AnchorFor(resultAaaFirst, "AAA"), AnchorFor(resultZzzFirst, "AAA"));
+        }
+
+        [Test]
+        public void AssignTheSameIdToZzzRegardlessOfInputOrder()
+        {
+            string resultAaaFirst = DeterministicYaml.RemapSubAssetIds(yamlAaaFirst, SEED);
+            string resultZzzFirst = DeterministicYaml.RemapSubAssetIds(yamlZzzFirst, SEED);
+
+            Assert.AreEqual(AnchorFor(resultAaaFirst, "ZZZ"), AnchorFor(resultZzzFirst, "ZZZ"));
+        }
+
+        [Test]
+        public void ReturnInputUnchangedWhenNoSubAssetDocsPresent()
+        {
+            const string yaml =
+                "fileFormatVersion: 2\n" +
+                "guid: deadbeefdeadbeefdeadbeefdeadbeef\n" +
+                "NativeFormatImporter:\n";
+
+            Assert.AreEqual(yaml, DeterministicYaml.RemapSubAssetIds(yaml, SEED));
+        }
+
+        [Test]
+        public void RemapASingleSubAsset()
+        {
+            string yaml = YAML_HEADER + CLIP_AAA;
+
+            string result = DeterministicYaml.RemapSubAssetIds(yaml, SEED);
+
+            Assert.AreNotEqual("7400000000000000001", AnchorFor(result, "AAA"));
+        }
+    }
+
+    [TestFixture]
+    [Category("EditModeCI")]
+    public class DeterministicYamlReorderTosOrderShould
+    {
+        // Mapping form, deliberately out of CRC order: 23966416, then 0, then a
+        // smaller-than-23966416 key (12345) to force an actual reorder.
+        private const string TOS_MAPPING_UNSORTED =
+            "AnimatorController:\n" +
+            "  m_Name: MyController\n" +
+            "  m_TOS:\n" +
+            "    23966416: Loop\n" +
+            "    0: \n" +
+            "    12345: Armature\n" +
+            "  m_StateMachineBehaviours: []\n";
+
+        private const string TOS_MAPPING_SORTED =
+            "AnimatorController:\n" +
+            "  m_Name: MyController\n" +
+            "  m_TOS:\n" +
+            "    0: \n" +
+            "    12345: Armature\n" +
+            "    23966416: Loop\n" +
+            "  m_StateMachineBehaviours: []\n";
+
+        // Sequence form (first/second pairs), out of CRC order.
+        private const string TOS_SEQUENCE_UNSORTED =
+            "AnimatorController:\n" +
+            "  m_Name: MyController\n" +
+            "  m_TOS:\n" +
+            "  - first: 23966416\n" +
+            "    second: Loop\n" +
+            "  - first: 0\n" +
+            "    second: \n" +
+            "  - first: 12345\n" +
+            "    second: Armature\n" +
+            "  m_StateMachineBehaviours: []\n";
+
+        [Test]
+        public void SortMappingFormEntriesAscendingByCrcKey()
+        {
+            Assert.AreEqual(TOS_MAPPING_SORTED, DeterministicYaml.ReorderTosOrder(TOS_MAPPING_UNSORTED));
+        }
+
+        [Test]
+        public void SortSequenceFormEntriesAscendingByCrcKey()
+        {
+            string result = DeterministicYaml.ReorderTosOrder(TOS_SEQUENCE_UNSORTED);
+
+            int idxZero = result.IndexOf("first: 0", System.StringComparison.Ordinal);
+            int idxMid = result.IndexOf("first: 12345", System.StringComparison.Ordinal);
+            int idxHigh = result.IndexOf("first: 23966416", System.StringComparison.Ordinal);
+
+            Assert.IsTrue(idxZero < idxMid && idxMid < idxHigh,
+                "Sequence-form m_TOS entries were not sorted ascending by crc");
+        }
+
+        [Test]
+        public void KeepSecondLineWithItsFirstLineWhenReorderingSequenceForm()
+        {
+            string result = DeterministicYaml.ReorderTosOrder(TOS_SEQUENCE_UNSORTED);
+
+            // The continuation "second:" must travel with its "- first:" header.
+            Assert.IsTrue(result.Contains("  - first: 0\n    second: \n"),
+                "second: continuation was detached from its first: entry");
+        }
+
+        [Test]
+        public void ReturnAlreadySortedMappingUnchanged()
+        {
+            Assert.AreEqual(TOS_MAPPING_SORTED, DeterministicYaml.ReorderTosOrder(TOS_MAPPING_SORTED));
+        }
+
+        [Test]
+        public void LeaveTextOutsideTosBlocksByteIdentical()
+        {
+            string result = DeterministicYaml.ReorderTosOrder(TOS_MAPPING_UNSORTED);
+
+            Assert.IsTrue(
+                result.StartsWith("AnimatorController:\n  m_Name: MyController\n  m_TOS:\n") &&
+                result.EndsWith("  m_StateMachineBehaviours: []\n"));
+        }
+
+        [Test]
+        public void PreserveCrlfLineEndings()
+        {
+            string crlf =
+                "AnimatorController:\r\n" +
+                "  m_Name: MyController\r\n" +
+                "  m_TOS:\r\n" +
+                "    23966416: Loop\r\n" +
+                "    0: \r\n" +
+                "  m_StateMachineBehaviours: []\r\n";
+
+            string result = DeterministicYaml.ReorderTosOrder(crlf);
+
+            // Reordered (so output differs) but every terminator must remain CRLF.
+            Assert.IsFalse(Regex.IsMatch(result, "(?<!\r)\n"),
+                "A line terminator was emitted as LF instead of CRLF");
+        }
+
+        [Test]
+        public void EmitReorderedCrlfBlockAscendingByCrc()
+        {
+            string crlf =
+                "  m_TOS:\r\n" +
+                "    23966416: Loop\r\n" +
+                "    0: \r\n";
+
+            string expected =
+                "  m_TOS:\r\n" +
+                "    0: \r\n" +
+                "    23966416: Loop\r\n";
+
+            Assert.AreEqual(expected, DeterministicYaml.ReorderTosOrder(crlf));
+        }
+
+        [Test]
+        public void ReturnInputUnchangedWhenNoTosBlockPresent()
+        {
+            const string yaml =
+                "AnimatorController:\n" +
+                "  m_Name: MyController\n" +
+                "  m_StateMachineBehaviours: []\n";
+
+            Assert.AreEqual(yaml, DeterministicYaml.ReorderTosOrder(yaml));
+        }
+
+        [Test]
+        public void ReturnInputUnchangedWhenTosBlockIsEmpty()
+        {
+            const string yaml =
+                "AnimatorController:\n" +
+                "  m_Name: MyController\n" +
+                "  m_TOS:\n" +
+                "  m_StateMachineBehaviours: []\n";
+
+            Assert.AreEqual(yaml, DeterministicYaml.ReorderTosOrder(yaml));
+        }
+    }
+}

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Tests/DeterministicYamlShould.cs.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Tests/DeterministicYamlShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5f6fedb4bb874df9afda246c3bbb8b9a

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
@@ -363,7 +363,13 @@ namespace DCL.ABConverter
             return false;
         }
 
-        public static MD5 md5 = new MD5CryptoServiceProvider();
+        // One MD5 instance per thread: ComputeHash mutates internal state during a hash,
+        // so a single shared instance is not safe under concurrent callers. The editor is
+        // single-threaded today, but several call sites now share this; a per-thread
+        // instance keeps it correct without allocating a new MD5 on every call.
+        private static readonly System.Threading.ThreadLocal<MD5> md5PerThread
+            = new System.Threading.ThreadLocal<MD5>(MD5.Create);
+        public static MD5 md5 => md5PerThread.Value;
 
         public static string CidToGuid(string cid)
         {


### PR DESCRIPTION
Make BuildAssetBundles output byte-for-byte reproducible by assigning deterministic GUIDs (md5 of a CID-derived seed via Utils.CidToGuid) to every generated/embedded asset that previously got a random Unity import GUID, and fixing the metadata timestamp:
  - GLTF, extracted textures, materials, animator controllers, metadata.json (generalizes the existing SetDeterministicAssetDatabaseGuid into SetDeterministicGuid(path, seed)).
  - AssetBundleMetadata.timestamp -> 0 (was DateTime.UtcNow.Ticks).

Bump the bundle version so the new deterministic population is namespaced and never collides with the existing random one