### PR TITLE
feat: long-lived Unity worker — phase 1 foundation

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Utils.cs
@@ -315,6 +315,12 @@ namespace DCL.ABConverter
         {
             Debug.Log($"Process finished with code {errorCode}");
 
+            // Worker mode: turn the exit into an exception caught at the
+            // request boundary so the Unity process stays alive to serve the
+            // next request. Stays false in Phase 1 — no behaviour change.
+            if (DCL.ABConverter.Worker.WorkerServer.IsActive)
+                throw new DCL.ABConverter.Worker.ConversionAbort(errorCode);
+
             if (Application.isBatchMode)
                 EditorApplication.Exit(errorCode);
         }

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Worker.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Worker.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 587b567221cd4332bf299a7a8476ca0a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Worker/ConversionAbort.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Worker/ConversionAbort.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace DCL.ABConverter.Worker
+{
+    // Thrown in place of EditorApplication.Exit when a long-lived worker is
+    // serving requests, so a per-conversion failure aborts the in-flight
+    // request without killing the Unity process. Caught at the request
+    // boundary in RequestRouter (Phase 2); the exit code becomes the response
+    // payload.
+    public class ConversionAbort : Exception
+    {
+        public int Code { get; }
+
+        public ConversionAbort(int code) : base($"Conversion aborted with code {code}")
+        {
+            Code = code;
+        }
+    }
+}

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Worker/ConversionAbort.cs.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Worker/ConversionAbort.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 484a1ed650aa43b7b076641806202cf6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Worker/WorkerServer.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Worker/WorkerServer.cs
@@ -1,0 +1,11 @@
+namespace DCL.ABConverter.Worker
+{
+    public static class WorkerServer
+    {
+        // Phase 1 stub: stays false until Phase 2 wires up the long-lived
+        // request-loop entry method. While false, Utils.Exit / ForceExit keep
+        // their existing batch-mode-kills-the-process semantics — the refactor
+        // is a no-op at runtime.
+        public static bool IsActive;
+    }
+}

--- a/asset-bundle-converter/Assets/AssetBundleConverter/Worker/WorkerServer.cs.meta
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/Worker/WorkerServer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 517642dfc0ad41fd8062a1fac95ebff8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/consumer-server/src/logic/conversion-task.ts
+++ b/consumer-server/src/logic/conversion-task.ts
@@ -311,6 +311,14 @@ export async function executeLODConversion(
   const unityBuildTarget = getUnityBuildTarget($BUILD_TARGET)
 
   const logger = components.logs.getLogger(`ExecuteConversion`)
+  const $UNITY_WORKER_ENABLED = parseBooleanFlag(
+    await components.config.getString('UNITY_WORKER_ENABLED'),
+    false,
+    (raw) =>
+      logger.warn(
+        `Unrecognized value for UNITY_WORKER_ENABLED: "${raw}" — falling back to the default (false). Accepted values: true/false/1/0/yes/no/on/off.`
+      )
+  )
 
   const cdnBucket = await components.scenes.getCdnBucket()
   const logFile = `/tmp/lods_logs/export_log_${entityId}_${Date.now()}.txt`
@@ -403,11 +411,14 @@ export async function executeLODConversion(
     } catch (err: any) {
       logger.error(err, defaultLoggerMetadata)
     }
-    // delete library folder
-    try {
-      await rimraf(`${$PROJECT_PATH}/Library`, { maxRetries: 3 })
-    } catch (err: any) {
-      logger.error(err, defaultLoggerMetadata)
+    // Library is preserved across requests in worker mode — that warm
+    // AssetDatabase is the whole point of keeping Unity alive.
+    if (!$UNITY_WORKER_ENABLED) {
+      try {
+        await rimraf(`${$PROJECT_PATH}/Library`, { maxRetries: 3 })
+      } catch (err: any) {
+        logger.error(err, defaultLoggerMetadata)
+      }
     }
 
     // delete scene manifest folder
@@ -448,6 +459,14 @@ export async function executeConversion(
     logger.warn(
       `Unrecognized value for ASSET_REUSE_ENABLED: "${raw}" — falling back to the default (true). Accepted values: true/false/1/0/yes/no/on/off.`
     )
+  )
+  const $UNITY_WORKER_ENABLED = parseBooleanFlag(
+    await components.config.getString('UNITY_WORKER_ENABLED'),
+    false,
+    (raw) =>
+      logger.warn(
+        `Unrecognized value for UNITY_WORKER_ENABLED: "${raw}" — falling back to the default (false). Accepted values: true/false/1/0/yes/no/on/off.`
+      )
   )
 
   // unityBuildTarget is also computed inside probeScene's validation step, but
@@ -861,17 +880,21 @@ export async function executeConversion(
     } catch (err: any) {
       logger.error(err, defaultLoggerMetadata)
     }
-    // delete library folder
-    try {
-      await rimraf(`${$PROJECT_PATH}/Library`, { maxRetries: 3 })
-    } catch (err: any) {
-      logger.error(`Error deleting library folder: ${err}`, defaultLoggerMetadata)
-    }
-    //delete _Download folder
-    try {
-      await rimraf(`${$PROJECT_PATH}/Assets/_Downloaded`, { maxRetries: 3 })
-    } catch (err: any) {
-      logger.error(err, defaultLoggerMetadata)
+    // Library and _Downloaded are preserved across requests in worker mode —
+    // the warm AssetDatabase is the whole point of keeping Unity alive, and
+    // _Downloaded is flat-by-hash (Config.cs:35-44) so shared assets across
+    // conversions get free download skips.
+    if (!$UNITY_WORKER_ENABLED) {
+      try {
+        await rimraf(`${$PROJECT_PATH}/Library`, { maxRetries: 3 })
+      } catch (err: any) {
+        logger.error(`Error deleting library folder: ${err}`, defaultLoggerMetadata)
+      }
+      try {
+        await rimraf(`${$PROJECT_PATH}/Assets/_Downloaded`, { maxRetries: 3 })
+      } catch (err: any) {
+        logger.error(err, defaultLoggerMetadata)
+      }
     }
 
     // delete scene manifest folder


### PR DESCRIPTION
## Context

Today every SQS conversion request spawns a fresh `Unity -batchmode` process via `spawn(...)` in `consumer-server/src/adapters/unity-runner/component.ts:217-237`. Each spawn pays Unity's bootstrap cost — load editor, load project, scan AssetDatabase, warm shader cache — before doing any conversion work. `CLAUDE.md` calls Unity spawns "minutes long," and the bootstrap is a meaningful fraction of that.

Container concurrency is **1** (verified: `consumer-server/src/service.ts:38-61` + `consumer-server/src/logic/task-queue.ts:78-95`), so a single warm Unity process per container fully matches the existing concurrency model. No worker pool needed — just one persistent child whose lifetime spans many conversions.

This PR is the **no-op foundation** slice. With `UNITY_WORKER_ENABLED` unset (default false), behaviour is byte-identical to `main`. Phase 2 lands the actual worker server, IPC transport, and adapter.

## What's in this PR (Phase 1)

**Consumer-server (`consumer-server/src/logic/conversion-task.ts`):**
- New env var `UNITY_WORKER_ENABLED` parsed via the existing `parseBooleanFlag` helper in both `executeConversion` and `executeLODConversion`.
- Cleanup `finally` blocks in both functions become conditional. With the flag off, behaviour is unchanged. With it on: `logFile`, `outDirectory`, `_SceneManifest` still get rimraf'd; `$PROJECT_PATH/Library` and `Assets/_Downloaded` are preserved — that warm state is the whole point.

**Unity (`asset-bundle-converter/Assets/AssetBundleConverter/Worker/`):**
- New `WorkerServer.cs` stub with `public static bool IsActive` (hardcoded false in Phase 1).
- New `ConversionAbort.cs` exception type carrying the int exit code.
- `Utils.cs:Exit` now checks `WorkerServer.IsActive` and throws `ConversionAbort(errorCode)` instead of calling `EditorApplication.Exit` when active. Since `IsActive` stays false through Phase 1, this is a no-op at runtime.

All 20 audited exit sites (from an exit-surface inventory I ran) funnel through `Utils.Exit` — either directly or via `AssetBundleEditor.Exit` / `ForceExit`. A single hook covers the full surface, no per-site refactor needed.

## What's coming in Phase 2

Tracked separately. Highlights from the design:

**Unity side (new files under `Assets/AssetBundleConverter/Worker/`):**
- `WorkerServer.Start()` — new `-executeMethod` entry. Connects to a Unix domain socket, sends `{type:"ready"}`, loops on `EditorApplication.update` reading framed requests.
- `Transport.cs` — 4-byte BE length prefix + UTF-8 JSON framing.
- `RequestRouter.cs` — per request: build `ClientSettings`, call `SceneClient.ConvertEntityById`, catch `ConversionAbort`, reset per-request statics (`PlatformUtils.currentTarget`, `SceneClient.env`), send response. Hooks `Application.logMessageReceivedThreaded` for per-request log redirection.
- Two genuinely fatal exit codes (`GLTFAST_CRITICAL_ERROR`, `INVALID_PLATFORM`) get a separate \"finish response then exit\" path that lets the consumer-server detect the death cleanly and respawn.

**Consumer-server side (new files under `src/adapters/unity-worker/`):**
- `UnityWorker` component implementing `IUnityRunnerComponent` so callers don't change.
- State machine: `spawning | ready | busy | recycling | crashed`.
- `ensureReady` / `recycle(reason)` / `stop` lifecycle hooks.
- 10s ping heartbeat while idle; three misses → force-recycle.
- `components.ts:110` branches on `UNITY_WORKER_ENABLED` between the legacy and worker adapters.

**Recycle policy** (all tunable via env vars):

| Trigger | Default | Env var |
|---|---|---|
| Requests served ≥ N | 50 | `UNITY_WORKER_MAX_REQUESTS` |
| RSS ≥ M MB | 12288 | `UNITY_WORKER_MAX_RSS_MB` |
| Uptime ≥ T seconds | 7200 | `UNITY_WORKER_MAX_UPTIME_SEC` |
| Consecutive failures ≥ F | 3 | `UNITY_WORKER_MAX_CONSECUTIVE_FAILURES` |
| `GLTFAST_CRITICAL_ERROR` / `INVALID_PLATFORM` reported | — | always |

Recycle never preempts an in-flight conversion — it always waits for completion, then graceful-shutdowns the child.

**New metrics** (following the existing `ab_converter_{noun}_{verb|state}` convention):
- `ab_converter_worker_state{state}` (gauge, one-hot)
- `ab_converter_worker_spawns_total{reason}` (counter)
- `ab_converter_worker_requests_total{result}` (counter)
- `ab_converter_worker_request_duration_seconds` (histogram)
- `ab_converter_worker_uptime_seconds`, `ab_converter_worker_rss_bytes` (gauges)
- `ab_converter_worker_handshake_duration_seconds` (histogram — startup cost saved vs legacy)

**Tests:**
- C# editmode `WorkerExitSurfaceTests`: enumerate all 20 exit sites; assert no `EditorApplication.Exit` and a `ConversionAbort` with the correct code.
- Unit tests for the consumer-server adapter (state machine, recycle triggers, deadline abort, heartbeat).
- Integration: extend `createUnityRunnerMock` with a `createUnityWorkerMock` variant; assert (i) cleanup is conditional; (ii) `UNITY_WORKER_ENABLED=false` is byte-equivalent to today.
- E2E smoke: back-to-back conversions, assert second handshake-to-first-bundle <30% of first.

**Rollout** (Phase 3): Mac → Windows → WebGL pools, in that order. Shadow 24h, canary one container, then 10/50/100% over 48h. Rollback = flip env var; legacy path is untouched.

## Test plan

- [ ] Land this PR with `UNITY_WORKER_ENABLED` unset everywhere → expect byte-identical bundles vs `main` on a 5-scene corpus.
- [ ] Phase 2 PR will add the editmode `WorkerExitSurfaceTests` covering all 20 exit sites.
- [ ] Phase 2 PR will include an end-to-end smoke test (two scenes back-to-back, second one's wall-clock < 50% of first).

## Verification done in this PR

- `yarn build` in `consumer-server/` — clean.
- `yarn lint:fix` — clean (one minor formatting adjustment auto-applied).
- `yarn test` — all 524 tests pass.

## Risks / open questions

- **glTFast static caches across requests.** `GltfImport` keeps process-static caches; unbounded growth across 50 requests is plausible but not certain. Phase 2 RSS recycle trigger catches it; if needed, a `UNITY_WORKER_GLTFAST_RESET` toggle nulls them via reflection.
- **`EditorApplication.update` pumping while idle.** In `-batchmode -nographics` Unity pumps the update loop only when there's reason to. Long idle socket reads might not pump — Phase 2 mitigation is to do socket I/O on a background thread and marshal handlers back to main via `EditorApplication.delayCall`. Will validate in canary.
- **The ≥40% p50 drop is a hypothesis.** Canary is the validation. If savings come in at 15-20% the engineering cost may not justify Phase 3.

Full plan file lives locally at `~/.claude/plans/mutable-launching-cookie.md` and informed this design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)