### PR TITLE
fix: upgrade @well-known-components/interfaces to 1.5.2 so the redis component starts

### DIFF
--- a/consumer-server/package.json
+++ b/consumer-server/package.json
@@ -28,7 +28,7 @@
     "@sentry/node": "^8.27.0",
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/http-server": "^2.1.0",
-    "@well-known-components/interfaces": "^1.4.3",
+    "@well-known-components/interfaces": "^1.5.2",
     "@well-known-components/logger": "^3.1.3",
     "@well-known-components/metrics": "^2.1.0",
     "@well-known-components/pushable-channel": "^1.0.3",

--- a/consumer-server/src/components.ts
+++ b/consumer-server/src/components.ts
@@ -142,10 +142,15 @@ export async function initComponents(): Promise<AppComponents> {
   })
 
   // Declaration order matters: Lifecycle stops components sequentially in
-  // REVERSE declaration order. `redis` must come before `runner` so the Redis
-  // client is closed only after the runner drains in-flight conversions —
-  // otherwise every cache probe during the (minutes-long) drain window fails
-  // with "The client is closed".
+  // REVERSE declaration order. Two constraints:
+  // - The task queues must stop BEFORE `runner` (declared after it): closing
+  //   the memory queue is what unblocks the consume loops' `q.next()`, so the
+  //   runner's drain can finish. The SQS adapter has no stop hook, so this
+  //   only matters for tests/local dev — but a swapped order deadlocks them.
+  // - `redis` must stop AFTER `runner` (declared before it) so the client is
+  //   closed only once in-flight conversions drain — otherwise every cache
+  //   probe during the (minutes-long) drain window fails with "The client is
+  //   closed".
   return {
     config,
     logs,
@@ -153,11 +158,11 @@ export async function initComponents(): Promise<AppComponents> {
     statusChecks,
     fetch,
     metrics,
-    triageTaskQueue,
-    conversionTaskQueue,
     cdnS3,
     redis,
     runner,
+    triageTaskQueue,
+    conversionTaskQueue,
     sentry,
     publisher,
     filesystem,

--- a/consumer-server/src/components.ts
+++ b/consumer-server/src/components.ts
@@ -141,6 +141,11 @@ export async function initComponents(): Promise<AppComponents> {
     scenes
   })
 
+  // Declaration order matters: Lifecycle stops components sequentially in
+  // REVERSE declaration order. `redis` must come before `runner` so the Redis
+  // client is closed only after the runner drains in-flight conversions —
+  // otherwise every cache probe during the (minutes-long) drain window fails
+  // with "The client is closed".
   return {
     config,
     logs,
@@ -151,13 +156,13 @@ export async function initComponents(): Promise<AppComponents> {
     triageTaskQueue,
     conversionTaskQueue,
     cdnS3,
+    redis,
     runner,
     sentry,
     publisher,
     filesystem,
     catalyst,
     unityRunner,
-    redis,
     scenes,
     conversionOrchestrator
   }

--- a/consumer-server/yarn.lock
+++ b/consumer-server/yarn.lock
@@ -2315,15 +2315,6 @@
     on-finished "^2.4.1"
     path-to-regexp "^6.2.1"
 
-"@well-known-components/interfaces@^1.4.3":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/@well-known-components/interfaces/-/interfaces-1.4.3.tgz#026047966db480bd561a315fdc8116b88bf8d27a"
-  integrity sha512-roVtoOHG6uaH+nL4C0ISnAwkkopc2FLsS7fqX+roI22EdX9PAknPoImhPU8/3u6jgRAVpglX5Zj4nWZkSaXPkQ==
-  dependencies:
-    "@types/node" "^20.3.1"
-    "@types/node-fetch" "^2.5.12"
-    typed-url-params "^1.0.1"
-
 "@well-known-components/interfaces@^1.5.1", "@well-known-components/interfaces@^1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@well-known-components/interfaces/-/interfaces-1.5.2.tgz#ef7001a19d410459e65b216dd948d15be19e4efa"


### PR DESCRIPTION
## problem

since the redis caching pr (#292) landed, the consumer-server logs are full of:

```
[ERROR] (redis-component): Error checking existence of key "v49/assets/..."
[WARNING] (AssetReuse): redis hit-cache exists failed; falling back to S3 HEAD for this key {"error":"The client is closed"}
```

this is not a redis outage — the client was never connected:

- the app resolves `@well-known-components/interfaces@1.4.3` (locked from `^1.4.3`), whose `Lifecycle.run` only recognizes string-keyed `component.start` / `component.stop` hooks
- `@dcl/redis-component@3.1.0` exposes its lifecycle exclusively through the `START_COMPONENT` / `STOP_COMPONENT` symbols introduced in interfaces 1.5.x
- so `startComponents()` silently skipped the redis component, `client.connect()` never ran, and every `get`/`set`/`exists` rejected with node-redis `ClientClosedError` ("The client is closed")

node-redis v5 with the component's default options retries network errors forever with `isOpen` staying true, so this error can only mean never-connected (or closed-after-stop) — ruling out an outage.

the wrappers in `asset-reuse.ts` degrade gracefully (S3 HEAD / catalyst fetch), so conversions kept working — but with zero cache hits and constant log spam. it slipped through because the in-memory fallback (no `REDIS_URL`) needs no `start()`, so local dev and tests were unaffected.

## fix

- bump `@well-known-components/interfaces` to `^1.5.2`: its lifecycle supports both the symbol hooks and the legacy string hooks (the app's own string-keyed components keep working, now with a deprecation warn)
- declare `redis` before `runner` in the components object: the 1.5.x lifecycle stops components sequentially in reverse declaration order, so the redis client now closes only after the runner drains in-flight conversions (minutes long) — otherwise every cache probe during a sigterm / disk-pressure drain would fail with the same error

## verification

- runtime check against the upgraded package: a symbol-keyed component's start is invoked, and stop order is `runner -> redis`
- `yarn build` passes
- `test/unit/asset-reuse.spec.ts`: 176/176 pass