### PR TITLE
fix: handle -cutout materials in LOD converter

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/LODsConverter/Scripts/LODConversion.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/LODsConverter/Scripts/LODConversion.cs
@@ -535,8 +535,8 @@ public class LODConversion
                     Debug.Log($"[LOD]   Applying cutout to {mat.name}");
                     mat.EnableKeyword("_ALPHATEST_ON");
                     mat.DisableKeyword("_ALPHAPREMULTIPLY_ON");
-                    mat.DisableKeyword("_SURFACE_TYPE_TRANSPARENT");
-                    mat.SetFloat("_Surface", 0);
+                    mat.EnableKeyword("_SURFACE_TYPE_TRANSPARENT");
+                    mat.SetFloat("_Surface", 1);
                     mat.SetFloat("_BlendMode", 0);
                     mat.SetFloat("_AlphaCutoffEnable", 1);
                     mat.SetFloat("_AlphaClip", 1);

--- a/asset-bundle-converter/Assets/AssetBundleConverter/LODsConverter/Scripts/LODConversion.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/LODsConverter/Scripts/LODConversion.cs
@@ -195,24 +195,30 @@ public class LODConversion
         Directory.CreateDirectory(texturesFolder);
         string texturesFolderRelative = PathUtils.GetRelativePathTo(Application.dataPath, texturesFolder);
 
-        // Build a set of texture names used by transparent materials
-        var transparentTextureNames = new HashSet<string>();
+        // Build a set of texture names that must preserve their alpha channel.
+        // Materials baked with the LOD generator carry a suffix indicating their
+        // surface mode: `-transparent` for alpha-blend, `-cutout` for alpha-clip
+        // (foliage). Both require the source alpha to survive into the asset
+        // bundle — otherwise leaves render as solid planes.
+        var needsAlphaTextureNames = new HashSet<string>();
         var allAssets = AssetDatabase.LoadAllAssetsAtPath(pathHandler.filePathRelativeToDataPath);
         foreach (var asset in allAssets)
         {
-            if (asset is Material mat && mat.name.Contains("-transparent", StringComparison.OrdinalIgnoreCase))
+            if (asset is not Material mat) continue;
+            bool isTransparent = mat.name.Contains("-transparent", StringComparison.OrdinalIgnoreCase);
+            bool isCutout = mat.name.Contains("-cutout", StringComparison.OrdinalIgnoreCase);
+            if (!isTransparent && !isCutout) continue;
+
+            var shader = mat.shader;
+            for (int i = 0; i < shader.GetPropertyCount(); i++)
             {
-                var shader = mat.shader;
-                for (int i = 0; i < shader.GetPropertyCount(); i++)
-                {
-                    if (shader.GetPropertyType(i) != UnityEngine.Rendering.ShaderPropertyType.Texture)
-                        continue;
-                    var tex = mat.GetTexture(shader.GetPropertyName(i)) as Texture2D;
-                    if (tex != null && !string.IsNullOrEmpty(tex.name))
-                        transparentTextureNames.Add(tex.name);
-                }
-                Debug.Log($"[LOD] Transparent material found: {mat.name}");
+                if (shader.GetPropertyType(i) != UnityEngine.Rendering.ShaderPropertyType.Texture)
+                    continue;
+                var tex = mat.GetTexture(shader.GetPropertyName(i)) as Texture2D;
+                if (tex != null && !string.IsNullOrEmpty(tex.name))
+                    needsAlphaTextureNames.Add(tex.name);
             }
+            Debug.Log($"[LOD] Alpha-preserving material found: {mat.name} ({(isTransparent ? "transparent" : "cutout")})");
         }
 
         int texIdx = 0;
@@ -221,7 +227,7 @@ public class LODConversion
             if (asset is Texture2D tex)
             {
                 string texName = string.IsNullOrEmpty(tex.name) ? $"texture_{texIdx}" : tex.name;
-                bool needsAlpha = transparentTextureNames.Contains(texName);
+                bool needsAlpha = needsAlphaTextureNames.Contains(texName);
 
                 // Blit to a readable RenderTexture to get pixel data
                 var rt = RenderTexture.GetTemporary(tex.width, tex.height, 0, RenderTextureFormat.ARGB32);
@@ -519,6 +525,29 @@ public class LODConversion
                     mat.SetFloat("_ZTestDepthEqualForOpaque", 4f);
                     mat.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
                     mat.color = new Color(mat.color.r, mat.color.g, mat.color.b, 0.8f);
+                }
+                else if (mat.name.Contains("-cutout", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Cutout (alpha-clip): opaque blend that depth-writes correctly,
+                    // with shader-side alpha testing. Right setup for foliage —
+                    // alpha-blend would z-sort wrong and plain opaque drops alpha.
+                    // DCL/Scene_TexArray supports _Cutoff / _AlphaClip / _ALPHATEST_ON.
+                    Debug.Log($"[LOD]   Applying cutout to {mat.name}");
+                    mat.EnableKeyword("_ALPHATEST_ON");
+                    mat.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+                    mat.DisableKeyword("_SURFACE_TYPE_TRANSPARENT");
+                    mat.SetFloat("_Surface", 0);
+                    mat.SetFloat("_BlendMode", 0);
+                    mat.SetFloat("_AlphaCutoffEnable", 1);
+                    mat.SetFloat("_AlphaClip", 1);
+                    mat.SetFloat("_Cutoff", 0.5f);
+                    mat.SetFloat("_SrcBlend", 1f);
+                    mat.SetFloat("_DstBlend", 0f);
+                    mat.SetFloat("_AlphaSrcBlend", 1f);
+                    mat.SetFloat("_AlphaDstBlend", 0f);
+                    mat.SetFloat("_ZWrite", 1f);
+                    mat.SetOverrideTag("RenderType", "TransparentCutout");
+                    mat.renderQueue = (int)UnityEngine.Rendering.RenderQueue.AlphaTest;
                 }
 
                 string matName = $"{mat.name.Replace("(Instance)", pathHandler.fileNameWithoutExtension)}.mat";


### PR DESCRIPTION
## Summary
- Generalize `ExtractTextures` to treat both `-transparent` *and* `-cutout` material names as alpha-preserving — cutout textures now get extracted as PNG instead of JPG.
- Add a `-cutout` branch to `SetLODShaderMaterial` that configures the `DCL/Scene_TexArray` material for alpha clipping: `_ALPHATEST_ON` enabled, `_AlphaClip=1`, `_Cutoff=0.5`, opaque blend, render queue `AlphaTest`, `RenderType=TransparentCutout`.
- Rename the local set to `needsAlphaTextureNames` to reflect that it now covers both surface modes.

## Why
The LOD generator ([lod-generator-unity#35](https://github.com/decentraland/lod-generator-unity/pull/35)) now bakes scenes into **three** material buckets per LOD GLB: opaque, cutout (alpha-clip, e.g. foliage), and transparent (alpha-blend). The output materials are named with a corresponding suffix.

Without this fix, ABC drops cutout into the opaque path:

1. `ExtractTextures` ([LODConversion.cs:198-216](../blob/feature/glb-to-asset-bundle-v2/asset-bundle-converter/Assets/AssetBundleConverter/LODsConverter/Scripts/LODConversion.cs#L198-L216)) only matched `-transparent`, so cutout textures got JPG-encoded and lost their alpha channel.
2. `SetLODShaderMaterial` ([LODConversion.cs:507-522](../blob/feature/glb-to-asset-bundle-v2/asset-bundle-converter/Assets/AssetBundleConverter/LODsConverter/Scripts/LODConversion.cs#L507-L522)) only re-applied alpha settings to `-transparent` materials after the `DCL/Scene_TexArray` shader swap. Cutout materials defaulted to opaque with `_ALPHATEST_ON` disabled, undoing the `alphaMode=MASK` signal from the GLB.

Net effect: foliage leaves came through the asset bundle as solid planes despite the GLB carrying correct alpha-clip metadata.

The `DCL/Scene_TexArray` shader already supports cutout — it exposes `_Cutoff` ([shader L14](../blob/feature/glb-to-asset-bundle-v2/asset-bundle-converter/Assets/git-submodules/unity-shared-dependencies/Runtime/Shaders/Scene/SceneRendering/TexArray/Scene_TexArray.shader#L14)), `_AlphaClip` ([shader L46](../blob/feature/glb-to-asset-bundle-v2/asset-bundle-converter/Assets/git-submodules/unity-shared-dependencies/Runtime/Shaders/Scene/SceneRendering/TexArray/Scene_TexArray.shader#L46)), and the `_ALPHATEST_ON` shader feature on main / shadow / depth passes. No shader work needed — just configure the material.

## Test plan
- [ ] Run a LOD conversion on a tree-bearing scene (e.g. one with `TreeGreen.glb`) — verify the resulting `-cutout.mat` in the asset bundle has `_ALPHATEST_ON` enabled and a PNG base map (not JPG).
- [ ] Load the AB in the runtime client — foliage renders with alpha-clipped leaves, not solid planes.
- [ ] Re-run an existing opaque-only and transparent-only scene to confirm no regression on those paths.

## Variant inclusion note
`_ALPHATEST_ON` is declared as `shader_feature_local_fragment` on the relevant passes — so variant inclusion in the AB depends on at least one material in the bundle having the keyword enabled. With this change, cutout materials do enable it, so the variant should ship. If any explicit variant-strip rules elsewhere need an entry, please flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)