### PR TITLE
fix: harden sqs job validation against ssrf and path traversal

### DIFF
--- a/consumer-server/.env.default
+++ b/consumer-server/.env.default
@@ -30,3 +30,7 @@ AB_VERSION=v1
 # storage plus Unity -cachedHashes filtering). When false (or unset for WebGL), the
 # converter uses the legacy per-entity upload path.
 ASSET_REUSE_ENABLED=true
+
+# SSRF allowlist for the SQS job's content-server URL (issue #306). Required —
+# comma-separated content-server hosts the worker is permitted to fetch from.
+ALLOWED_CONTENT_SERVER_HOSTS=peer.decentraland.org,peer-ec1.decentraland.org,peer-ec2.decentraland.org,peer-wc1.decentraland.org,peer-eu1.decentraland.org,peer-ap1.decentraland.org,interconnected.online,peer.melonwave.com,peer.uadevops.com,peer.dclnodes.io,worlds-content-server.decentraland.org,peer-testing.decentraland.org,peer-testing-2.decentraland.org,peer.decentraland.zone,peer-ap1.decentraland.zone,worlds-content-server.decentraland.zone

--- a/consumer-server/src/logic/conversion-orchestrator/component.ts
+++ b/consumer-server/src/logic/conversion-orchestrator/component.ts
@@ -1,7 +1,12 @@
 import { AssetBundleConversionFinishedEvent, Events } from '@dcl/schemas'
 import { DeploymentToSqs } from '@dcl/schemas/dist/misc/deployments-to-sqs'
 import { AppComponents, TestComponents } from '../../types'
-import { getAbVersionEnvName } from '../../utils'
+import {
+  getAbVersionEnvName,
+  isAllowedContentServerUrl,
+  isSafeOutboundUrl,
+  parseAllowedContentServerHosts
+} from '../../utils'
 import { executeConversion, executeLODConversion, executeTriagePass, parseBooleanFlag } from '../conversion-task'
 import { ConversionQueueRepublishFailedError } from './errors'
 import type { IConversionOrchestratorComponent, Platform } from './types'
@@ -46,6 +51,17 @@ export async function createConversionOrchestratorComponent(
       `Unrecognized value for FAST_PATH_TRIAGE_ENABLED: "${raw}" — falling back to the default (false). Accepted values: true/false/1/0/yes/no/on/off.`
     )
   )
+  // Strict host allowlist for the (attacker-influenced) content-server URL.
+  // Read once at construction so per-message validation stays off the config
+  // hot path. Sourced entirely from ALLOWED_CONTENT_SERVER_HOSTS (set per-env in the
+  // definitions repo) — required, with no built-in fallback list.
+  const allowedContentServerHosts = parseAllowedContentServerHosts(
+    await config.requireString('ALLOWED_CONTENT_SERVER_HOSTS')
+  )
+  if (allowedContentServerHosts.size === 0) {
+    throw new Error('ALLOWED_CONTENT_SERVER_HOSTS is set but contains no valid catalyst hosts')
+  }
+  logger.info(`Catalyst allowlist active with ${allowedContentServerHosts.size} host(s)`)
 
   /**
    * Validates the shape of an incoming SQS job before either loop tries
@@ -71,12 +87,48 @@ export async function createConversionOrchestratorComponent(
       })
       return false
     }
+    if (!/^[a-zA-Z0-9]+$/.test(job.entity.entityId)) {
+      // entityId flows unmodified into filesystem paths (outDirectory, logFile)
+      // and S3 keys (manifest/<entityId>...). A real entity id is a bare CID
+      // ([a-zA-Z0-9]); reject anything with separators or `..` to prevent
+      // path traversal (arbitrary file write) and S3-key injection (overwriting
+      // another entity's manifest). Mirrors the catalyst adapter's CID check.
+      logger.warn('Skipping job: entityId is not a bare CID (path/key-injection guard)', {
+        entityId: String(job.entity.entityId).slice(0, 80)
+      })
+      return false
+    }
     if (!job.lods && !job.contentServerUrls?.[0]) {
       // Non-LOD jobs MUST carry at least one content server URL — both the
       // probe (catalyst entity fetch) and Unity asset resolution need it.
       // Without this guard, the `[0]!` non-null assertion downstream produces
       // an `undefined` URL that fails opaquely deep inside fetch logic.
       logger.warn('Skipping job with no contentServerUrls — not a conversion job', {
+        entityId: job.entity.entityId
+      })
+      return false
+    }
+    // SSRF guard: the content-server URL is fetched by the worker (and handed to
+    // Unity/the encoder). It rides in the SQS payload, so a crafted job could
+    // otherwise drive a request to cloud metadata (169.254.169.254) or an
+    // internal service. Pin it to the configured allowlist (HTTPS + exact host
+    // match) — stricter than the IP/internal heuristic used for LODs. Validate
+    // EVERY entry, not just [0]: the whole array is preserved in the message, so
+    // a future consumer that iterates it must not see an off-allowlist host.
+    const disallowedContentServerUrl = job.contentServerUrls?.find(
+      (url) => !isAllowedContentServerUrl(url, allowedContentServerHosts)
+    )
+    if (disallowedContentServerUrl) {
+      logger.warn('Skipping job: a contentServerUrl is not an allowed content server (SSRF/allowlist guard)', {
+        entityId: job.entity.entityId,
+        contentServerUrl: String(disallowedContentServerUrl).slice(0, 120)
+      })
+      return false
+    }
+    // LOD source URLs come from a varying set of CDN hosts, so they get the
+    // looser IP-literal/internal-host heuristic rather than a fixed allowlist.
+    if (job.lods?.some((u) => !isSafeOutboundUrl(u))) {
+      logger.warn('Skipping job: a LOD source URL is not a safe outbound URL (SSRF guard)', {
         entityId: job.entity.entityId
       })
       return false

--- a/consumer-server/src/utils.ts
+++ b/consumer-server/src/utils.ts
@@ -1,3 +1,5 @@
+import { isIP } from 'net'
+
 export function getUnityBuildTarget(target: string): string | undefined {
   switch (target) {
     case 'webgl':
@@ -34,6 +36,105 @@ export function normalizeContentsBaseUrl(url: string): string {
     out += 'contents/'
   }
   return out
+}
+
+// Loopback / internal-only DNS suffixes a public LOD host should never use.
+// IP-literal hosts (incl. the cloud-metadata IP) are blocked separately via isIP.
+const INTERNAL_HOST_SUFFIXES = ['.localhost', '.local', '.internal', '.corp', '.home', '.arpa', '.onion']
+
+/**
+ * SSRF guard for an attacker-influenced outbound URL. Used for the LOD source
+ * URLs from the SQS job — the worker, Unity and the encoder fetch these, so a
+ * job pointing at `http://169.254.169.254/...` or an internal host would turn
+ * the converter into an SSRF primitive against cloud metadata / internal
+ * services.
+ *
+ * Rejects IP-literal hosts (legit catalysts/CDNs use DNS names — this blocks the
+ * metadata IP and internal IPs directly) and obvious loopback/internal names.
+ * It does NOT pin a domain allowlist: LOD CDN hosts vary, so an allowlist risks
+ * rejecting legit jobs. The content-server URL is the attacker-influenced field
+ * that DOES get a strict host allowlist — see {@link isAllowedContentServerUrl}.
+ * Code-level guards are inherently bypassable (obfuscated IPs, DNS rebinding) —
+ * pair with an egress network control that blocks link-local/RFC1918 from the
+ * conversion pods.
+ */
+export function isSafeOutboundUrl(raw: string): boolean {
+  let u: URL
+  try {
+    u = new URL(raw)
+  } catch {
+    return false
+  }
+  // HTTPS only — LOD content must not be fetched over plaintext (no MITM /
+  // protocol-downgrade tampering), matching the content-server requirement.
+  if (u.protocol !== 'https:') return false
+  const host = u.hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  if (host.length === 0) return false
+  // IP-literal host (v4/v6) → reject: blocks the cloud-metadata IP
+  // (169.254.169.254) and internal IPs; legit content/LOD servers are named.
+  if (isIP(host) !== 0) return false
+  // Loopback / internal-only TLDs that should never host public LOD content.
+  if (host === 'localhost' || INTERNAL_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix))) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Normalize one allowlist entry to a bare lowercase hostname. Accepts either a
+ * bare host (`peer.decentraland.org`) or a full URL (`https://peer…/content`) —
+ * the latter is tolerated because the sibling `deployments-to-sqs` config lists
+ * content servers as full URLs, so an operator copying that format won't
+ * silently produce an empty allowlist. Returns undefined for blank/unparseable
+ * entries so the caller can drop them.
+ */
+function normalizeContentServerHost(entry: string): string | undefined {
+  const trimmed = entry.trim().toLowerCase()
+  if (trimmed.length === 0) return undefined
+  if (trimmed.includes('/')) {
+    try {
+      const withScheme = /^[a-z][a-z0-9+.-]*:\/\//.test(trimmed) ? trimmed : `https://${trimmed}`
+      const host = new URL(withScheme).hostname.replace(/^\[|\]$/g, '').toLowerCase()
+      return host.length > 0 ? host : undefined
+    } catch {
+      return undefined
+    }
+  }
+  return trimmed
+}
+
+/**
+ * Parse the `ALLOWED_CONTENT_SERVER_HOSTS` env var (a comma-separated list of catalyst
+ * hosts) into a Set of normalized hostnames for {@link isAllowedContentServerUrl}.
+ * There is no built-in fallback list: the allowlist is sourced entirely from
+ * config (set per-environment in the `definitions` repo), so the orchestrator
+ * requires the var and rejects an empty result at startup rather than silently
+ * running with no allowlist.
+ */
+export function parseAllowedContentServerHosts(raw: string | undefined): Set<string> {
+  const hosts = (raw ?? '')
+    .split(',')
+    .map(normalizeContentServerHost)
+    .filter((h): h is string => h !== undefined)
+  return new Set(hosts)
+}
+
+/**
+ * Strict SSRF guard for the content-server URL of an SQS job: requires HTTPS and
+ * an exact host match against the configured catalyst allowlist. An exact match
+ * (not a suffix) is intentional — it's the whole point of an allowlist and the
+ * catalyst hosts are a known finite set (issue #306).
+ */
+export function isAllowedContentServerUrl(raw: string, allowedHosts: Set<string>): boolean {
+  let u: URL
+  try {
+    u = new URL(raw)
+  } catch {
+    return false
+  }
+  if (u.protocol !== 'https:') return false
+  const host = u.hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  return allowedHosts.has(host)
 }
 
 export function getAbVersionEnvName(buildTarget: string) {

--- a/consumer-server/test/integration/service-skip-non-conversion.spec.ts
+++ b/consumer-server/test/integration/service-skip-non-conversion.spec.ts
@@ -56,7 +56,8 @@ describe('when the conversion worker consumes a job from the queue', () => {
       BUILD_TARGET: 'windows',
       AB_VERSION_WINDOWS: 'v48',
       AB_VERSION_MAC: 'v48',
-      AB_VERSION: ''
+      AB_VERSION: '',
+      ALLOWED_CONTENT_SERVER_HOSTS: 'peer.decentraland.org'
     })
     const metrics = await createMetricsComponent(metricDeclarations, { config })
     const logs = await createLogComponent({ metrics })
@@ -131,7 +132,7 @@ describe('when the conversion worker consumes a job from the queue', () => {
       // worker did — and didn't — do for each.
       await triageTaskQueue.publish({ type: 'world_undeployment' } as any)
       await triageTaskQueue.publish({
-        entity: { entityId: 'bafy-valid-after-skip', authChain: [] as any },
+        entity: { entityId: 'bafyvalidafterskip', authChain: [] as any },
         contentServerUrls: ['https://peer.decentraland.org/content']
       })
       await waitFor(() => mockedExecuteConversion.mock.calls.length >= 1)
@@ -144,7 +145,7 @@ describe('when the conversion worker consumes a job from the queue', () => {
     it('should pass the valid job entity id to executeConversion', () => {
       expect(mockedExecuteConversion).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-valid-after-skip',
+        'bafyvalidafterskip',
         'https://peer.decentraland.org/content',
         undefined,
         undefined,
@@ -161,7 +162,7 @@ describe('when the conversion worker consumes a job from the queue', () => {
       expect(publishMessage).toHaveBeenCalledTimes(1)
       expect(publishMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({ entityId: 'bafy-valid-after-skip' })
+          metadata: expect.objectContaining({ entityId: 'bafyvalidafterskip' })
         })
       )
     })
@@ -171,7 +172,7 @@ describe('when the conversion worker consumes a job from the queue', () => {
     beforeEach(async () => {
       await triageTaskQueue.publish({ entity: { entityId: '', authChain: [] as any } } as any)
       await triageTaskQueue.publish({
-        entity: { entityId: 'bafy-valid-after-empty', authChain: [] as any },
+        entity: { entityId: 'bafyvalidafterempty', authChain: [] as any },
         contentServerUrls: ['https://peer.decentraland.org/content']
       })
       await waitFor(() => mockedExecuteConversion.mock.calls.length >= 1)
@@ -181,7 +182,7 @@ describe('when the conversion worker consumes a job from the queue', () => {
       expect(mockedExecuteConversion).toHaveBeenCalledTimes(1)
       expect(mockedExecuteConversion).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-valid-after-empty',
+        'bafyvalidafterempty',
         expect.any(String),
         undefined,
         undefined,

--- a/consumer-server/test/integration/triage-then-conversion.spec.ts
+++ b/consumer-server/test/integration/triage-then-conversion.spec.ts
@@ -60,7 +60,8 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
       AB_VERSION_WINDOWS: 'v48',
       AB_VERSION_MAC: 'v48',
       AB_VERSION: '',
-      FAST_PATH_TRIAGE_ENABLED: 'true'
+      FAST_PATH_TRIAGE_ENABLED: 'true',
+      ALLOWED_CONTENT_SERVER_HOSTS: 'peer.decentraland.org'
     })
     const metrics = await createMetricsComponent(metricDeclarations, { config })
     const logs = await createLogComponent({ metrics })
@@ -131,7 +132,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
       mockedExecuteTriagePass.mockResolvedValue({ kind: 'completed', exitCode: 0 })
       conversionPublishSpy = jest.spyOn(conversionTaskQueue, 'publish')
       await triageTaskQueue.publish({
-        entity: { entityId: 'bafy-fast-hit', authChain: [] as any },
+        entity: { entityId: 'bafyfasthit', authChain: [] as any },
         contentServerUrls: ['https://peer.decentraland.org/content']
       })
       await waitFor(() => mockedExecuteTriagePass.mock.calls.length >= 1)
@@ -140,7 +141,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
     it('should call executeTriagePass for the job', () => {
       expect(mockedExecuteTriagePass).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-fast-hit',
+        'bafyfasthit',
         'https://peer.decentraland.org/content',
         undefined,
         undefined,
@@ -160,7 +161,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
       await waitFor(() => publishMessage.mock.calls.length >= 1)
       expect(publishMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({ entityId: 'bafy-fast-hit', statusCode: 0 })
+          metadata: expect.objectContaining({ entityId: 'bafyfasthit', statusCode: 0 })
         })
       )
     })
@@ -174,7 +175,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
       mockedExecuteConversion.mockResolvedValue(0)
       conversionPublishSpy = jest.spyOn(conversionTaskQueue, 'publish')
       await triageTaskQueue.publish({
-        entity: { entityId: 'bafy-cache-miss', authChain: [] as any },
+        entity: { entityId: 'bafycachemiss', authChain: [] as any },
         contentServerUrls: ['https://peer.decentraland.org/content']
       })
       await waitFor(() => conversionPublishSpy.mock.calls.length >= 1)
@@ -183,7 +184,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
     it('should republish the job to the Conversion queue', () => {
       expect(conversionPublishSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          entity: expect.objectContaining({ entityId: 'bafy-cache-miss' })
+          entity: expect.objectContaining({ entityId: 'bafycachemiss' })
         }),
         false
       )
@@ -193,7 +194,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
       await waitFor(() => mockedExecuteConversion.mock.calls.length >= 1)
       expect(mockedExecuteConversion).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-cache-miss',
+        'bafycachemiss',
         'https://peer.decentraland.org/content',
         undefined,
         undefined,
@@ -210,9 +211,9 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
       mockedExecuteLODConversion.mockResolvedValue(0)
       conversionPublishSpy = jest.spyOn(conversionTaskQueue, 'publish')
       await triageTaskQueue.publish({
-        entity: { entityId: 'bafy-lod-job', authChain: [] as any },
+        entity: { entityId: 'bafylodjob', authChain: [] as any },
         contentServerUrls: ['https://peer.decentraland.org/content'],
-        lods: ['lod1.glb']
+        lods: ['https://lod-cdn.example.com/lod1.glb']
       } as any)
       await waitFor(() => conversionPublishSpy.mock.calls.length >= 1)
     })
@@ -226,8 +227,8 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
       await waitFor(() => mockedExecuteLODConversion.mock.calls.length >= 1)
       expect(mockedExecuteLODConversion).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-lod-job',
-        ['lod1.glb'],
+        'bafylodjob',
+        ['https://lod-cdn.example.com/lod1.glb'],
         'v48',
         'https://peer.decentraland.org/content'
       )
@@ -241,7 +242,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
       mockedExecuteTriagePass.mockResolvedValue({ kind: 'failed', exitCode: 5 })
       conversionPublishSpy = jest.spyOn(conversionTaskQueue, 'publish')
       await triageTaskQueue.publish({
-        entity: { entityId: 'bafy-failed-probe', authChain: [] as any },
+        entity: { entityId: 'bafyfailedprobe', authChain: [] as any },
         contentServerUrls: ['https://peer.decentraland.org/content']
       })
       await waitFor(() => publishMessage.mock.calls.length >= 1)
@@ -250,7 +251,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
     it('should publish a finished event with the failure status code', () => {
       expect(publishMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({ entityId: 'bafy-failed-probe', statusCode: 5 })
+          metadata: expect.objectContaining({ entityId: 'bafyfailedprobe', statusCode: 5 })
         })
       )
     })
@@ -272,7 +273,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
       mockedExecuteConversion.mockResolvedValue(0)
       conversionPublishSpy = jest.spyOn(conversionTaskQueue, 'publish')
       await triageTaskQueue.publish({
-        entity: { entityId: 'bafy-force-job', authChain: [] as any },
+        entity: { entityId: 'bafyforcejob', authChain: [] as any },
         contentServerUrls: ['https://peer.decentraland.org/content'],
         force: true
       } as any)
@@ -282,7 +283,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
     it('should republish the job to the Conversion queue with force preserved', () => {
       expect(conversionPublishSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          entity: expect.objectContaining({ entityId: 'bafy-force-job' }),
+          entity: expect.objectContaining({ entityId: 'bafyforcejob' }),
           force: true
         }),
         false
@@ -293,7 +294,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
       await waitFor(() => mockedExecuteConversion.mock.calls.length >= 1)
       expect(mockedExecuteConversion).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-force-job',
+        'bafyforcejob',
         'https://peer.decentraland.org/content',
         true,
         undefined,
@@ -315,7 +316,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
       conversionPublishSpy = jest.spyOn(conversionTaskQueue, 'publish')
       await triageTaskQueue.publish(
         {
-          entity: { entityId: 'bafy-priority-job', authChain: [] as any },
+          entity: { entityId: 'bafypriorityjob', authChain: [] as any },
           contentServerUrls: ['https://peer.decentraland.org/content']
         },
         true /* prioritize */
@@ -326,7 +327,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
     it('should republish to the Conversion queue with prioritize=true', () => {
       expect(conversionPublishSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          entity: expect.objectContaining({ entityId: 'bafy-priority-job' })
+          entity: expect.objectContaining({ entityId: 'bafypriorityjob' })
         }),
         true
       )
@@ -347,11 +348,11 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
       // Malformed non-LOD job (no contentServerUrls) — should be skipped by
       // the validation guard before any of the conversion paths fire.
       await triageTaskQueue.publish({
-        entity: { entityId: 'bafy-malformed', authChain: [] as any }
+        entity: { entityId: 'bafymalformed', authChain: [] as any }
       } as any)
       // Valid job behind it confirms the loop advanced past the skip.
       await triageTaskQueue.publish({
-        entity: { entityId: 'bafy-valid-after-malformed', authChain: [] as any },
+        entity: { entityId: 'bafyvalidaftermalformed', authChain: [] as any },
         contentServerUrls: ['https://peer.decentraland.org/content']
       })
       await waitFor(() => mockedExecuteTriagePass.mock.calls.length >= 1)
@@ -361,7 +362,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is true', () => {
       expect(mockedExecuteTriagePass).toHaveBeenCalledTimes(1)
       expect(mockedExecuteTriagePass).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-valid-after-malformed',
+        'bafyvalidaftermalformed',
         'https://peer.decentraland.org/content',
         undefined,
         undefined,
@@ -389,7 +390,8 @@ describe('when FAST_PATH_TRIAGE_ENABLED is unset (default off)', () => {
       BUILD_TARGET: 'windows',
       AB_VERSION_WINDOWS: 'v48',
       AB_VERSION_MAC: 'v48',
-      AB_VERSION: ''
+      AB_VERSION: '',
+      ALLOWED_CONTENT_SERVER_HOSTS: 'peer.decentraland.org'
     })
     const metrics = await createMetricsComponent(metricDeclarations, { config })
     const logs = await createLogComponent({ metrics })
@@ -455,7 +457,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is unset (default off)', () => {
     beforeEach(async () => {
       conversionPublishSpy = jest.spyOn(conversionTaskQueue, 'publish')
       await triageTaskQueue.publish({
-        entity: { entityId: 'bafy-default-mode', authChain: [] as any },
+        entity: { entityId: 'bafydefaultmode', authChain: [] as any },
         contentServerUrls: ['https://peer.decentraland.org/content']
       })
       await waitFor(() => mockedExecuteConversion.mock.calls.length >= 1)
@@ -464,7 +466,7 @@ describe('when FAST_PATH_TRIAGE_ENABLED is unset (default off)', () => {
     it('should call executeConversion directly (today behavior)', () => {
       expect(mockedExecuteConversion).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-default-mode',
+        'bafydefaultmode',
         'https://peer.decentraland.org/content',
         undefined,
         undefined,

--- a/consumer-server/test/unit/conversion-orchestrator.spec.ts
+++ b/consumer-server/test/unit/conversion-orchestrator.spec.ts
@@ -50,7 +50,8 @@ async function buildHarness(opts: { triageEnabled: boolean }): Promise<Harness> 
     AB_VERSION_WINDOWS: 'v48',
     AB_VERSION_MAC: 'v48',
     AB_VERSION: '',
-    FAST_PATH_TRIAGE_ENABLED: opts.triageEnabled ? 'true' : 'false'
+    FAST_PATH_TRIAGE_ENABLED: opts.triageEnabled ? 'true' : 'false',
+    ALLOWED_CONTENT_SERVER_HOSTS: 'peer.decentraland.org'
   })
   const metrics = await createMetricsComponent(metricDeclarations, { config })
   const logs = await createLogComponent({ metrics })
@@ -80,16 +81,16 @@ async function buildHarness(opts: { triageEnabled: boolean }): Promise<Harness> 
 
 function buildValidSceneJob(): DeploymentToSqs {
   return {
-    entity: { entityId: 'bafy-scene', authChain: [] as any },
+    entity: { entityId: 'bafyscene', authChain: [] as any },
     contentServerUrls: ['https://peer.decentraland.org/content']
   } as any
 }
 
 function buildValidLodJob(): DeploymentToSqs {
   return {
-    entity: { entityId: 'bafy-lod', authChain: [] as any },
+    entity: { entityId: 'bafylod', authChain: [] as any },
     contentServerUrls: ['https://peer.decentraland.org/content'],
-    lods: ['lod-1.glb', 'lod-2.glb']
+    lods: ['https://lod-cdn.example.com/lod-1.glb', 'https://lod-cdn.example.com/lod-2.glb']
   } as any
 }
 
@@ -125,12 +126,70 @@ describe('when processIncomingJob is called and FAST_PATH_TRIAGE_ENABLED is fals
   describe('and the job has an entityId but no contentServerUrls', () => {
     beforeEach(async () => {
       await harness.orchestrator.processIncomingJob(
-        { entity: { entityId: 'bafy-noUrls', authChain: [] as any } } as any,
+        { entity: { entityId: 'bafynoUrls', authChain: [] as any } } as any,
         false
       )
     })
 
     it('should skip the job (validation guard rejects empty contentServerUrls)', () => {
+      expect(mockedExecuteConversion).not.toHaveBeenCalled()
+      expect(harness.publisher.publishMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the job entityId is not a bare CID', () => {
+    beforeEach(async () => {
+      await harness.orchestrator.processIncomingJob(
+        {
+          entity: { entityId: '../../etc/passwd', authChain: [] as any },
+          contentServerUrls: ['https://peer.decentraland.org/content']
+        } as any,
+        false
+      )
+    })
+
+    it('should skip the job (path/key-injection guard rejects the entityId)', () => {
+      expect(mockedExecuteConversion).not.toHaveBeenCalled()
+      expect(harness.publisher.publishMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the job carries a contentServerUrl that is not an allowed catalyst', () => {
+    beforeEach(async () => {
+      // Bare-CID entityId so the path-traversal guard passes and validation
+      // reaches the catalyst allowlist check — the metadata IP is not allowlisted.
+      await harness.orchestrator.processIncomingJob(
+        {
+          entity: { entityId: 'bafyssrf', authChain: [] as any },
+          contentServerUrls: ['https://169.254.169.254/latest/meta-data/']
+        } as any,
+        false
+      )
+    })
+
+    it('should skip the job (SSRF allowlist guard rejects the content server URL)', () => {
+      expect(mockedExecuteConversion).not.toHaveBeenCalled()
+    })
+
+    it('should not publish a finished event for the rejected job', () => {
+      expect(harness.publisher.publishMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and a later contentServerUrl entry is not an allowed catalyst', () => {
+    beforeEach(async () => {
+      // First entry is allowlisted, second is not — the whole array is preserved
+      // in the message, so every entry must be validated, not just [0].
+      await harness.orchestrator.processIncomingJob(
+        {
+          entity: { entityId: 'bafymulti', authChain: [] as any },
+          contentServerUrls: ['https://peer.decentraland.org/content', 'https://evil.internal/ssrf']
+        } as any,
+        false
+      )
+    })
+
+    it('should skip the job even though the first URL is allowlisted', () => {
       expect(mockedExecuteConversion).not.toHaveBeenCalled()
       expect(harness.publisher.publishMessage).not.toHaveBeenCalled()
     })
@@ -145,7 +204,7 @@ describe('when processIncomingJob is called and FAST_PATH_TRIAGE_ENABLED is fals
     it('should call executeConversion with the entity and content server URL', () => {
       expect(mockedExecuteConversion).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-scene',
+        'bafyscene',
         'https://peer.decentraland.org/content',
         undefined,
         undefined,
@@ -157,7 +216,7 @@ describe('when processIncomingJob is called and FAST_PATH_TRIAGE_ENABLED is fals
     it('should publish a finished event with the conversion exit code', () => {
       expect(harness.publisher.publishMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({ entityId: 'bafy-scene', statusCode: 0 })
+          metadata: expect.objectContaining({ entityId: 'bafyscene', statusCode: 0 })
         })
       )
     })
@@ -172,8 +231,8 @@ describe('when processIncomingJob is called and FAST_PATH_TRIAGE_ENABLED is fals
     it('should call executeLODConversion (not executeConversion)', () => {
       expect(mockedExecuteLODConversion).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-lod',
-        ['lod-1.glb', 'lod-2.glb'],
+        'bafylod',
+        ['https://lod-cdn.example.com/lod-1.glb', 'https://lod-cdn.example.com/lod-2.glb'],
         'v48',
         'https://peer.decentraland.org/content'
       )
@@ -183,7 +242,7 @@ describe('when processIncomingJob is called and FAST_PATH_TRIAGE_ENABLED is fals
     it('should publish a finished event with isLods=true', () => {
       expect(harness.publisher.publishMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({ isLods: true, entityId: 'bafy-lod' })
+          metadata: expect.objectContaining({ isLods: true, entityId: 'bafylod' })
         })
       )
     })
@@ -225,7 +284,7 @@ describe('when processIncomingJob is called and FAST_PATH_TRIAGE_ENABLED is true
     it('should republish the job to the Conversion queue without calling executeTriagePass', () => {
       expect(mockedExecuteTriagePass).not.toHaveBeenCalled()
       expect(harness.conversionPublish).toHaveBeenCalledWith(
-        expect.objectContaining({ entity: expect.objectContaining({ entityId: 'bafy-lod' }) }),
+        expect.objectContaining({ entity: expect.objectContaining({ entityId: 'bafylod' }) }),
         false
       )
     })
@@ -244,7 +303,7 @@ describe('when processIncomingJob is called and FAST_PATH_TRIAGE_ENABLED is true
     it('should publish a finished event carrying the triage exit code', () => {
       expect(harness.publisher.publishMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({ entityId: 'bafy-scene', statusCode: 0 })
+          metadata: expect.objectContaining({ entityId: 'bafyscene', statusCode: 0 })
         })
       )
     })
@@ -263,7 +322,7 @@ describe('when processIncomingJob is called and FAST_PATH_TRIAGE_ENABLED is true
     it('should publish a finished event carrying the failure exit code so downstream consumers see the failure', () => {
       expect(harness.publisher.publishMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({ entityId: 'bafy-scene', statusCode: 5 })
+          metadata: expect.objectContaining({ entityId: 'bafyscene', statusCode: 5 })
         })
       )
     })
@@ -281,7 +340,7 @@ describe('when processIncomingJob is called and FAST_PATH_TRIAGE_ENABLED is true
 
     it('should republish the original job to the Conversion queue with prioritize=false', () => {
       expect(harness.conversionPublish).toHaveBeenCalledWith(
-        expect.objectContaining({ entity: expect.objectContaining({ entityId: 'bafy-scene' }) }),
+        expect.objectContaining({ entity: expect.objectContaining({ entityId: 'bafyscene' }) }),
         false
       )
     })
@@ -323,7 +382,7 @@ describe('when processIncomingJob is called and FAST_PATH_TRIAGE_ENABLED is true
     it('should fall back to running the full conversion inline so no work is lost', () => {
       expect(mockedExecuteConversion).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-scene',
+        'bafyscene',
         'https://peer.decentraland.org/content',
         undefined,
         undefined,
@@ -335,7 +394,7 @@ describe('when processIncomingJob is called and FAST_PATH_TRIAGE_ENABLED is true
     it('should publish a finished event carrying the inline-conversion exit code', () => {
       expect(harness.publisher.publishMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({ entityId: 'bafy-scene', statusCode: 0 })
+          metadata: expect.objectContaining({ entityId: 'bafyscene', statusCode: 0 })
         })
       )
     })
@@ -351,8 +410,8 @@ describe('when processIncomingJob is called and FAST_PATH_TRIAGE_ENABLED is true
     it('should fall back to running the LOD conversion inline', () => {
       expect(mockedExecuteLODConversion).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-lod',
-        ['lod-1.glb', 'lod-2.glb'],
+        'bafylod',
+        ['https://lod-cdn.example.com/lod-1.glb', 'https://lod-cdn.example.com/lod-2.glb'],
         'v48',
         'https://peer.decentraland.org/content'
       )
@@ -361,7 +420,7 @@ describe('when processIncomingJob is called and FAST_PATH_TRIAGE_ENABLED is true
     it('should publish a finished event for the inline LOD conversion', () => {
       expect(harness.publisher.publishMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({ entityId: 'bafy-lod', isLods: true, statusCode: 0 })
+          metadata: expect.objectContaining({ entityId: 'bafylod', isLods: true, statusCode: 0 })
         })
       )
     })
@@ -418,7 +477,7 @@ describe('when processConversionJob is called', () => {
     it('should call executeConversion with the entity', () => {
       expect(mockedExecuteConversion).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-scene',
+        'bafyscene',
         'https://peer.decentraland.org/content',
         undefined,
         undefined,
@@ -430,7 +489,7 @@ describe('when processConversionJob is called', () => {
     it('should publish a finished event with the conversion exit code', () => {
       expect(harness.publisher.publishMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({ entityId: 'bafy-scene', statusCode: 0 })
+          metadata: expect.objectContaining({ entityId: 'bafyscene', statusCode: 0 })
         })
       )
     })
@@ -445,8 +504,8 @@ describe('when processConversionJob is called', () => {
     it('should call executeLODConversion (not executeConversion)', () => {
       expect(mockedExecuteLODConversion).toHaveBeenCalledWith(
         expect.anything(),
-        'bafy-lod',
-        ['lod-1.glb', 'lod-2.glb'],
+        'bafylod',
+        ['https://lod-cdn.example.com/lod-1.glb', 'https://lod-cdn.example.com/lod-2.glb'],
         'v48',
         'https://peer.decentraland.org/content'
       )

--- a/consumer-server/test/unit/utils.spec.ts
+++ b/consumer-server/test/unit/utils.spec.ts
@@ -1,0 +1,150 @@
+// Unit coverage for the catalyst allowlist guard (issue #306). The
+// content-server URL rides in the attacker-influenced SQS payload, so it is
+// validated against a strict HTTPS + exact-host allowlist before the worker
+// fetches from it. The allowlist is sourced entirely from the ALLOWED_CONTENT_SERVER_HOSTS
+// env var — there is no built-in default list. The LOD-oriented
+// isSafeOutboundUrl heuristic is covered alongside it.
+
+import { isAllowedContentServerUrl, isSafeOutboundUrl, parseAllowedContentServerHosts } from '../../src/utils'
+
+describe('when parsing the ALLOWED_CONTENT_SERVER_HOSTS env var', () => {
+  describe('and the value is undefined', () => {
+    let result: Set<string>
+
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts(undefined)
+    })
+
+    it('should produce an empty set (no built-in default)', () => {
+      expect(result.size).toBe(0)
+    })
+  })
+
+  describe('and the value is a comma-separated list of bare hostnames', () => {
+    let result: Set<string>
+
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts('peer.example.org, peer-2.example.org')
+    })
+
+    it('should trim each entry and produce the configured hosts', () => {
+      expect(result).toEqual(new Set(['peer.example.org', 'peer-2.example.org']))
+    })
+  })
+
+  describe('and an entry is a full URL rather than a bare host', () => {
+    let result: Set<string>
+
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts('https://peer.example.org/content,peer-2.example.org')
+    })
+
+    it('should normalize the URL entry down to its hostname', () => {
+      expect(result).toEqual(new Set(['peer.example.org', 'peer-2.example.org']))
+    })
+  })
+
+  describe('and the value is uppercased', () => {
+    let result: Set<string>
+
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts('PEER.EXAMPLE.ORG')
+    })
+
+    it('should lowercase the host so matching is case-insensitive', () => {
+      expect(result).toEqual(new Set(['peer.example.org']))
+    })
+  })
+
+  describe('and the value contains only separators and whitespace', () => {
+    let result: Set<string>
+
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts('  , ,')
+    })
+
+    it('should produce an empty set', () => {
+      expect(result.size).toBe(0)
+    })
+  })
+})
+
+describe('when validating a content-server URL against the catalyst allowlist', () => {
+  let allowed: Set<string>
+
+  beforeEach(() => {
+    allowed = parseAllowedContentServerHosts('peer.decentraland.org, worlds-content-server.decentraland.org')
+  })
+
+  describe('and the URL is an HTTPS allowlisted catalyst', () => {
+    it('should accept it', () => {
+      expect(isAllowedContentServerUrl('https://peer.decentraland.org/content', allowed)).toBe(true)
+    })
+  })
+
+  describe('and the URL is an HTTPS allowlisted worlds content server', () => {
+    it('should accept it', () => {
+      expect(isAllowedContentServerUrl('https://worlds-content-server.decentraland.org/content', allowed)).toBe(true)
+    })
+  })
+
+  describe('and the host is not on the allowlist', () => {
+    it('should reject it', () => {
+      expect(isAllowedContentServerUrl('https://evil.example.com/content', allowed)).toBe(false)
+    })
+  })
+
+  describe('and the URL points at the cloud metadata IP', () => {
+    it('should reject it (no IP literal is on the allowlist)', () => {
+      expect(isAllowedContentServerUrl('https://169.254.169.254/latest/meta-data/', allowed)).toBe(false)
+    })
+  })
+
+  describe('and an allowlisted host is requested over plain HTTP', () => {
+    it('should reject it because catalysts must be HTTPS', () => {
+      expect(isAllowedContentServerUrl('http://peer.decentraland.org/content', allowed)).toBe(false)
+    })
+  })
+
+  describe('and the value is not a parseable URL', () => {
+    it('should reject it', () => {
+      expect(isAllowedContentServerUrl('not a url', allowed)).toBe(false)
+    })
+  })
+
+  describe('and the allowlist is empty', () => {
+    it('should reject every URL', () => {
+      expect(isAllowedContentServerUrl('https://peer.decentraland.org/content', new Set())).toBe(false)
+    })
+  })
+})
+
+describe('when validating a LOD source URL with isSafeOutboundUrl', () => {
+  describe('and the URL is a named HTTPS host', () => {
+    it('should accept it', () => {
+      expect(isSafeOutboundUrl('https://lod-cdn.example.com/lod-1.glb')).toBe(true)
+    })
+  })
+
+  describe('and the URL is the cloud metadata IP literal', () => {
+    it('should reject it', () => {
+      expect(isSafeOutboundUrl('http://169.254.169.254/latest/meta-data/')).toBe(false)
+    })
+  })
+
+  describe('and the URL uses plain HTTP', () => {
+    it('should reject it (no protocol downgrade)', () => {
+      expect(isSafeOutboundUrl('http://lod-cdn.example.com/lod-1.glb')).toBe(false)
+    })
+  })
+
+  describe('and the URL targets an internal hostname', () => {
+    it('should reject a .internal host', () => {
+      expect(isSafeOutboundUrl('https://metadata.internal/lod.glb')).toBe(false)
+    })
+
+    it('should reject a .onion host', () => {
+      expect(isSafeOutboundUrl('https://abcd1234.onion/lod.glb')).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
self-contained fix for issue #306, branched from `main` so it can ship independently of the encoder feature branch.

the sqs job is consumed without enough validation, so a crafted message can drive the converter into ssrf (cloud metadata / internal services) or path traversal. the orchestrator's job validation now:

- **entityId**: rejects anything that isn't a bare cid (`[a-zA-Z0-9]+`) before it's interpolated into filesystem paths / s3 keys.
- **content-server url**: pins it to a strict https + exact-host allowlist — the attacker-influenced field the worker/unity/encoder fetch from.
- **lod urls**: keep the looser ip-literal/internal-host heuristic (`isSafeOutboundUrl`), since lod cdn hosts vary.

the allowlist is sourced entirely from the `ALLOWED_CONTENT_SERVER_HOSTS` env var (comma-separated hosts, set per-env in the `definitions` repo, with known defaults in `.env.default`). there is no built-in fallback — the orchestrator `requireString`s it and fails fast if unset/empty.

## tests
- new `test/unit/utils.spec.ts` for the allowlist + `isSafeOutboundUrl` helpers; entityId-reject and ssrf-reject tests in the orchestrator unit spec; the orchestrator-routed integration suites updated. 69 tests across the four suites pass; build + lint clean.

## relationship to #307
- #307 stacks the same change on `feat/asset-bundle-encoder` (where the encoder work lives). **this PR is the main-targeted equivalent** — merge whichever fits the release plan; they're mutually redundant.

## companion prs
deployments-to-sqs, ab-admin (ops-lambdas), asset-bundle-registry apply the same allowlist; `definitions` supplies `ALLOWED_CONTENT_SERVER_HOSTS`.

closes #306