### PR TITLE
fix: allow emote conversion for scene emotes in smart wearables

### DIFF
--- a/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
+++ b/asset-bundle-converter/Assets/AssetBundleConverter/AssetBundleConverter.cs
@@ -624,8 +624,8 @@ namespace DCL.ABConverter
         private AnimationMethod GetAnimationMethod(bool isEmote, bool isWearable)
         {
             if (entityDTO == null) return AnimationMethod.Legacy;
+            if (isEmote) return AnimationMethod.Mecanim; // emote files in smart wearables need to get Mecanim controller, that's why we check for isEmote first
             if (isWearable) return AnimationMethod.None;
-            if (isEmote) return AnimationMethod.Mecanim;
             return settings.AnimationMethod;
         }
 


### PR DESCRIPTION
Smart wearables that contain *_emote.glb files have both isEmote = true (detected via Utils.IsEmoteFileName on the _emote.glb suffix) and isWearable = true (from entityDTO.type == "wearable"). Because isWearable was checked first, AnimationMethod.None was returned and CreateAnimatorController was never called for those GLBs.

By inverting the checks now we are correctly converting them